### PR TITLE
Fixes issue #2 - Fatal Error: Cant use function return value in write context

### DIFF
--- a/admin/admin-setup.php
+++ b/admin/admin-setup.php
@@ -112,7 +112,7 @@ function superpwa_validater_and_sanitizer( $settings ) {
 	$settings['background_color'] = preg_match( '/#([a-f0-9]{3}){1,2}\b/i', $settings['background_color'] ) ? sanitize_text_field( $settings['background_color'] ) : '#D5E0EB';
 	
 	// Sanitize application icon
-	$settings['icon'] = empty( sanitize_text_field($settings['icon']) ) ? SUPERPWA_PATH_SRC . 'public/images/logo.png' : sanitize_text_field($settings['icon']);
+	$settings['icon'] = sanitize_text_field($settings['icon']) == '' ? SUPERPWA_PATH_SRC . 'public/images/logo.png' : sanitize_text_field($settings['icon']);
 	
 	return $settings;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,10 @@ If you have any questions, please ask it on the [support forum](https://wordpres
 
 == Changelog ==
 
+= 1.1.1 =
+* Date: 30.January.2018
+* Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context". PHP manual says "Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error."
+
 = 1.1 =
 * Date: 28.January.2018
 * Aggressive caching of pages using CacheStorage API.
@@ -131,6 +135,16 @@ If you have any questions, please ask it on the [support forum](https://wordpres
 * First release of the plugin.
 
 == Upgrade Notice ==
+
+= 1.1.1 =
+* Date: 30.January.2018
+* Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context". PHP manual says "Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error."
+
+= 1.1 =
+* Date: 28.January.2018
+* Aggressive caching of pages using CacheStorage API.
+* Pages once cached are served even if the user is offline. 
+* Set custom offline page: Select the page you want the user to see when a page that isn't in the cache is accessed and the user is offline.
 
 = 1.0 =
 * First release of the plugin.

--- a/superpwa.php
+++ b/superpwa.php
@@ -5,7 +5,7 @@
  * Description: Convert your WordPress website into a Progressive Web App
  * Author: SuperPWA
  * Contributors: Arun Basil Lal, Jose Varghese
- * Version: 1.1
+ * Version: 1.1.1
  * Text Domain: super-progressive-web-apps
  * Domain Path: /languages
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -47,7 +47,7 @@ if ( ! defined('ABSPATH') ) exit;
  */
 if ( ! defined('SUPERPWA_PATH_ABS ') ) 			define('SUPERPWA_PATH_ABS', plugin_dir_path( __FILE__ )); // absolute path to the plugin directory. eg - /var/www/html/wp-content/plugins/superpwa/
 if ( ! defined('SUPERPWA_PATH_SRC') ) 			define('SUPERPWA_PATH_SRC', plugin_dir_url( __FILE__ )); // link to the plugin folder. eg - http://example.com/wp/wp-content/plugins/superpwa/
-if ( ! defined('SUPERPWA_VERSION') ) 			define('SUPERPWA_VERSION', '1.1'); // Plugin version
+if ( ! defined('SUPERPWA_VERSION') ) 			define('SUPERPWA_VERSION', '1.1.1'); // Plugin version
 if ( ! defined('SUPERPWA_MANIFEST_FILENAME') ) 	define('SUPERPWA_MANIFEST_FILENAME', 'superpwa-manifest.json'); // Name of Manifest file
 if ( ! defined('SUPERPWA_MANIFEST_ABS') )		define('SUPERPWA_MANIFEST_ABS', trailingslashit( ABSPATH ) . SUPERPWA_MANIFEST_FILENAME); // Absolute path to manifest
 if ( ! defined('SUPERPWA_MANIFEST_SRC') )		define('SUPERPWA_MANIFEST_SRC', trailingslashit( get_bloginfo('wpurl') ) . SUPERPWA_MANIFEST_FILENAME); // Link to manifest


### PR DESCRIPTION
Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context". PHP manual says "Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error."