### PR TITLE
Feature Request: Native PWA Push Notifications with API

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://superpwa.com">
-    <img src="https://pbs.twimg.com/profile_images/975224418543681536/X9-CESOD_400x400.jpg" alt="" width=72 height=72>
+    <img src="https://pbs.twimg.com/profile_images/975224418543681536/X9-CESOD_400x400.jpg" alt="" width=150 height=150>
   </a>
 
   <h3 align="center">Super Progressive Web Apps</h3>

--- a/README.MD
+++ b/README.MD
@@ -171,13 +171,15 @@ There are various ways you can contribute:
 <a href="https://www.facebook.com/SuperPWA/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg" title="Follow SuperPWA on Facebook" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://www.instagram.com/superpwa/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174855.svg" title="Follow SuperPWA on Instagram" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Follow on Google+" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+
 * Send us a Pull Request with your bug fixes and/or new features.
 * Provide feedback and [suggestions on enhancements](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open).
 * ##### Share via Social Media's and spread SuperPWA
-    * [Share on Twitter](https://twitter.com/home?status=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA%20https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/%20%40SuperPWA)
-    * [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/)
-    * [Share on Google Plus](https://plus.google.com/share?url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/)
-    * [Share on LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/&title=Super%20Progressive%20Web%20Apps&summary=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA&source=GitHub)
+
+ &nbsp;&nbsp;&nbsp; <a href="https://twitter.com/home?status=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA%20https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/%20%40SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174876.svg" title="Share SuperPWA on Twitter" width=20 height=20> Share on Twitter </a>&nbsp;&nbsp;&nbsp;&nbsp;
+<p> &nbsp;&nbsp;&nbsp; <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg" title="Follow SuperPWA on Facebook" width=20 height=20> Share on Facebook </a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
+<p> &nbsp;&nbsp;&nbsp; <a href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/&title=Super%20Progressive%20Web%20Apps&summary=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA&source=GitHub" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174857.svg" title="Share SuperPWA on LinkedIn" width=20 height=20> Share on LinkedIn</a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
+<p> &nbsp;&nbsp;&nbsp; <a href="https://plus.google.com/share?url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Share on Google+" width=20 height=20> Share on Google+ </a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
     
 Emoji Credits : [Emojipedia](emojipedia.org)
 Social Media Icon Credits : [Flaticon](flaticon.com)

--- a/README.MD
+++ b/README.MD
@@ -74,10 +74,10 @@ Here are the current features of Super Progressive Web Apps:
 * Offline Indicator Notice.
  
  ### Device and Browser Support For PWA
- | <img src="https://user-images.githubusercontent.com/1215767/34348387-a2e64588-ea4d-11e7-8267-a43365103afe.png" alt="Chrome" width="16px" height="16px" /> Chrome | <img src="https://user-images.githubusercontent.com/1215767/34348383-9e7ed492-ea4d-11e7-910c-03b39d52f496.png" alt="Firefox" width="16px" height="16px" /> Firefox | <img src="https://user-images.githubusercontent.com/1215767/34348394-a981f892-ea4d-11e7-9156-d128d58386b9.png" alt="Safari" width="16px" height="16px" /> Safari | <img src="https://user-images.githubusercontent.com/1215767/34348380-93e77ae8-ea4d-11e7-8696-9a989ddbbbf5.png" alt="Edge" width="16px" height="16px" /> Edge | Opera Mini | Samsung Internet | Brave |
-| :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: |
-| Yes | Yes | Partially | Beta | No | Yes | Yes |
-| 57+ | 57+ | 11.3+ | 17 ships | - | 6.2+ | 1.0.44+
+ | <img src="https://user-images.githubusercontent.com/1215767/34348387-a2e64588-ea4d-11e7-8267-a43365103afe.png" alt="Chrome" width="16px" height="16px" /> Chrome | <img src="https://user-images.githubusercontent.com/1215767/34348383-9e7ed492-ea4d-11e7-910c-03b39d52f496.png" alt="Firefox" width="16px" height="16px" /> Firefox | <img src="https://user-images.githubusercontent.com/1215767/34348394-a981f892-ea4d-11e7-9156-d128d58386b9.png" alt="Safari" width="16px" height="16px" /> Safari | <img src="https://user-images.githubusercontent.com/1215767/34348380-93e77ae8-ea4d-11e7-8696-9a989ddbbbf5.png" alt="Edge" width="16px" height="16px" /> Edge | <img src="https://user-images.githubusercontent.com/1215767/34348380-93e77ae8-ea4d-11e7-8696-9a989ddbbbf5.png" alt="Edge" width="16px" height="16px" /> Edge (Mobile) | Opera Mini | Samsung Internet | Brave |
+| :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: |
+| Yes | Yes | Partially | Beta | Yes | No | Yes | Yes |
+| 57+ | 57+ | 11.3+ | 17 ships | 1.0.0.1921 | - | 6.2+ | 1.0.44+
 
 Progressive web apps need browsers that support manifests and service workers. Currently Google Chrome (version 57+), Chrome for Android (62), Mozilla Firefox (57), Firefox for Android (58) are the major browsers that support PWA. 
 

--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,7 @@
 
 ## Welcome to the Super PWA GitHub repository
 
-🔗 Demo :  <a href="https://superpwa.com/?utm=GitHub">superpwa.com</a>
+⚡️ Demo :  <a href="https://superpwa.com/?utm=GitHub">superpwa.com</a>
 
 ## What is Progressive Web Apps
 Progressive Web Apps (PWA) is a new technology that creates a middle ground between a website and a mobile app. They are installed on the phone like a normal app (web app) and can be accessed from the home screen. 
@@ -66,15 +66,15 @@ Users can come back to your website by launching the app from their home screen 
 
 <a href="https://superpwa.com">Super Progressive Web Apps</a> makes it easy for you to convert your WordPress website into a Progressive Web App easily!
 
-## Installation
-Once SuperPWA is installed, users browsing your website from a supported mobile device will see a "Add To Home Screen" notice (from the bottom of the screen) and will be able to 'install your website' on the home screen of their device. Every page visited is stored locally on their device and will be available to read even when they are offline!
+## 🏗 Installation
+Once SuperPWA ⚡️ is installed, users browsing your website from a supported mobile device will see a "Add To Home Screen" notice (from the bottom of the screen) and will be able to 'install your website' on the home screen of their device. Every page visited is stored locally on their device and will be available to read even when they are offline!
 
 SuperPWA is easy to configure, it takes less than a minute to set-up your Progressive Web App! SuperPWA does a clean uninstall, by removing every database entry and file that it creates. In fact, none of the default settings are saved to the database until you manually save it the first time. Go ahead and give it a try.
 
-### Progressive Web App Minimum Requirments
+### 💡 Progressive Web App Minimum Requirments
 - [x] Progressive Web Apps require that your WordPress website is served from a secure origin i.e. your website should be HTTPS and not HTTP. If your website isn’t HTTPS, please contact your host about it. You can also ask us [Support Forums](https://wordpress.org/support/plugin/super-progressive-web-apps) if you need help.
 
-#### What's in the box
+#### 📦 What's in the box
 
 Here are the current features of Super Progressive Web Apps: 
 
@@ -97,7 +97,7 @@ Here are the current features of Super Progressive Web Apps:
 * New in version 1.5: OneSignal integration for Push notifications.
 * New in version 1.6: WordPress Multisite Network compatibility.
 
-#### Upcoming features:
+#### 🔮 Upcoming features:
 * Offline Indicator Notice.
  
  ### Device and Browser Support For PWA
@@ -115,13 +115,13 @@ The list is fast growing and is likely to be supported in most major browsers by
 
 ### How To Convert Your WordPress Website Into A Progressive Web App
 
-#### WordPress Installation
+#### ⚙️ WordPress Installation
 
 * Visit WordPress Admin > **Plugins** > **Add New**
 * Search for **Super Progressive Web Apps**
 * Click "**Install Now**" and then "**Activate**" Super Progressive Web Apps
 
-#### To install manually:
+#### ⚙️ To install manually:
 
 * Upload super-progressive-web-apps folder to the /wp-content/plugins/ directory on your server
 * Go to WordPress Admin > **Plugins**
@@ -164,9 +164,12 @@ Anyone is welcome to contribute to Super PWA to make it SUPER.
 There are various ways you can contribute:
 
 * [Raise an issue](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues) on GitHub.
-* Engage with us on Social Media
-    * Follow us on [Twitter](https://twitter.com/SuperPWA)
-    * Like us on [Facebook](https://www.facebook.com/SuperPWA)
+* Follow and Engage with us on Social Media
+ &nbsp;&nbsp;&nbsp; <a href="https://twitter.com/SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174876.svg" alt="Follow on Twitter" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.youtube.com/channel/UCMFlNeutNCwTNls186moUUA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174883.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.facebook.com/SuperPWA/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.instagram.com/superpwa/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174855.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 * Send us a Pull Request with your bug fixes and/or new features.
 * Provide feedback and [suggestions on enhancements](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open).
 * ##### Share via Social Media's

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@
     ·
     <a href="https://wordpress.org/plugins/super-progressive-web-apps/#faq">FAQ</a>
     · 
-    <a href="#contributions">Contributions</a>
+    <a href="#-contributions">Contributions</a>
   </p>
 </p>
 

--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,35 @@
 
 
 </p>
-<p>
+
+<p align="center">
+  <a href="https://superpwa.com">
+    <img src="https://pbs.twimg.com/profile_images/975224418543681536/X9-CESOD_400x400.jpg" alt="" width=72 height=72>
+  </a>
+
+  <h3 align="center">Super Progressive Web Apps</h3>
+
+  <p align="center">
+    SuperPWA helps to convert your WordPress website into Progressive Web Apps easily.
+    <br>
+    <br>
+    <a href="https://superpwa.com"><strong>Visit Website »</strong></a>
+    <br>
+    <br>
+    <a href="https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/new?template=bug.md">Report bug</a>
+    ·
+    <a href="https://wordpress.org/plugins/super-progressive-web-apps/">WordPress Plugin</a>
+    ·
+    <a href="https://wordpress.org/support/plugin/super-progressive-web-apps/reviews/">Reviews</a>
+    ·
+    <a href="https://wordpress.org/plugins/super-progressive-web-apps/#faq">FAQ</a>
+    · 
+    <a href="#contributions">Contributions</a>
+  </p>
+</p>
+
+
+<p align="center">
 	<a href="https://superpwa.com">
 			<img src="https://lighthouse-badge.appspot.com?score=100" alt="LightHouse Score">
 	</a>
@@ -28,7 +56,6 @@
 </p>
 
 ## Welcome to the Super PWA GitHub repository
-> <a href="https://superpwa.com">SuperPWA</a> helps you convert your WordPress website into a Progressive Web App.
 
 🔗 Demo :  <a href="https://superpwa.com/?utm=GitHub">superpwa.com</a>
 

--- a/README.MD
+++ b/README.MD
@@ -148,17 +148,17 @@ Your Progressive Web App should be ready to test with the default settings upon 
 * Try visiting a page that you did not visit before. You should see the page you set as your "Offline Page" in the settings of SuperPWA. 
 
 
-### About us
+### 🤝 About us
 > We are a duo who got excited about the idea. Our mission is simple: Help you build an awesome PWA that your users would want to have on their home screen. When we first heard about PWA we wanted to learn everything about it. We have spent countless hours learning and wants to share it with the world. Please give us your constructive feedback and support. 
 
-## Support
+## ⛷️ Support
 This is a developer's portal for Super Progressive Web Apps and should not be used for support. Please visit the
 [Support Forums](https://wordpress.org/support/plugin/super-progressive-web-apps).
 
-## Reporting bugs
+## 🐛 Reporting bugs
 If you ever get stuck, we are here to watch your back! [Open a New Support Topic](https://wordpress.org/support/plugin/super-progressive-web-apps) ticket if you have a question or need a feature. We are super excited to hear your feedback and we want to genuinely help you build the best Progressive Web App for your WordPress website!
 
-## Contributions
+## 🎍 Contributions
 Anyone is welcome to contribute to Super PWA to make it SUPER.
 
 There are various ways you can contribute:
@@ -173,11 +173,14 @@ There are various ways you can contribute:
 <a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Follow on Google+" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 * Send us a Pull Request with your bug fixes and/or new features.
 * Provide feedback and [suggestions on enhancements](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open).
-* ##### Share via Social Media's
+* ##### Share via Social Media's and spread SuperPWA
     * [Share on Twitter](https://twitter.com/home?status=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA%20https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/%20%40SuperPWA)
     * [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/)
     * [Share on Google Plus](https://plus.google.com/share?url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/)
     * [Share on LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/&title=Super%20Progressive%20Web%20Apps&summary=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA&source=GitHub)
+    
+Emoji Credits : [Emojipedia](emojipedia.org)
+Social Media Icon Credits : [Flaticon](flaticon.com)
 
 **[⬆ back to top](#super-progressive-web-apps)**
 <img src="https://ga-beacon.appspot.com/UA-115873914-2/GitHub_Readme?pixel"/>

--- a/README.MD
+++ b/README.MD
@@ -165,11 +165,12 @@ There are various ways you can contribute:
 
 * [Raise an issue](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues) on GitHub.
 * Follow and Engage with us on Social Media
- &nbsp;&nbsp;&nbsp; <a href="https://twitter.com/SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174876.svg" alt="Follow on Twitter" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://www.youtube.com/channel/UCMFlNeutNCwTNls186moUUA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174883.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://www.facebook.com/SuperPWA/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://www.instagram.com/superpwa/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174855.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg"  width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+
+ &nbsp;&nbsp;&nbsp; <a href="https://twitter.com/SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174876.svg" title="Follow SuperPWA on Twitter" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.youtube.com/channel/UCMFlNeutNCwTNls186moUUA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174883.svg" title="Follow SuperPWA on YouTube" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.facebook.com/SuperPWA/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg" title="Follow SuperPWA on Facebook" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://www.instagram.com/superpwa/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174855.svg" title="Follow SuperPWA on Instagram" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Follow on Google+" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 * Send us a Pull Request with your bug fixes and/or new features.
 * Provide feedback and [suggestions on enhancements](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open).
 * ##### Share via Social Media's

--- a/README.MD
+++ b/README.MD
@@ -183,4 +183,3 @@ Emoji Credits : [Emojipedia](emojipedia.org)
 Social Media Icon Credits : [Flaticon](flaticon.com)
 
 **[⬆ back to top](#super-progressive-web-apps)**
-<img src="https://ga-beacon.appspot.com/UA-115873914-2/GitHub_Readme?pixel"/>

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,9 @@ PWA's require browsers with support for service workers and for iOS devices, sup
 
 == Changelog ==
 
+= 1.7 =
+* Date: 
+
 = 1.6 =
 * Date: 23.April.2018
 * New Feature: WordPress Multisite Network Compatibility. One of the most requested features for SuperPWA is now here! Thanks [@juslintek](https://wordpress.org/support/topic/add-manifest-json-support-for-multisite/#post-9998629) for doing a major share of the heavy lifting.

--- a/superpwa.php
+++ b/superpwa.php
@@ -6,7 +6,7 @@
  * Author: SuperPWA
  * Author URI: https://superpwa.com
  * Contributors: Arun Basil Lal, Jose Varghese
- * Version: 1.6
+ * Version: 1.7
  * Text Domain: super-progressive-web-apps
  * Domain Path: /languages
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -50,7 +50,7 @@ if ( ! defined('ABSPATH') ) exit;
  * @since 1.6 Depreciated constants for multisite compatibility: SUPERPWA_MANIFEST_FILENAME, SUPERPWA_MANIFEST_ABS, SUPERPWA_MANIFEST_SRC
  * @since 1.6 Depreciated constants for multisite compatibility: SUPERPWA_SW_FILENAME, SUPERPWA_SW_ABS, SUPERPWA_SW_SRC
  */
-if ( ! defined( 'SUPERPWA_VERSION' ) )		define( 'SUPERPWA_VERSION'	, '1.6' ); // SuperPWA current version
+if ( ! defined( 'SUPERPWA_VERSION' ) )		define( 'SUPERPWA_VERSION'	, '1.7' ); // SuperPWA current version
 if ( ! defined( 'SUPERPWA_PATH_ABS' ) ) 	define( 'SUPERPWA_PATH_ABS'	, plugin_dir_path( __FILE__ ) ); // Absolute path to the plugin directory. eg - /var/www/html/wp-content/plugins/super-progressive-web-apps/
 if ( ! defined( 'SUPERPWA_PATH_SRC' ) ) 	define( 'SUPERPWA_PATH_SRC'	, plugin_dir_url( __FILE__ ) ); // Link to the plugin folder. eg - http://example.com/wp/wp-content/plugins/super-progressive-web-apps/
 


### PR DESCRIPTION
With the addition of cleaning up conflicts for 3rd party push notification plugins, can we use native PWA features into the service worker for push notifications?

Example:
https://auth0.com/blog/introduction-to-progressive-web-apps-push-notifications-part-3/

Then in settings have boxes to put in API info from sources like Firebase or option to use 3rd party WordPress plugin as an if statement for the vars?

I'd rather use native code in a single service worker then have extra, unnecessary WordPress plugins to compensate.

Thanks for hearing me out!