### PR TITLE
New feature request: obtain a link to manually install the pwa

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@
     SuperPWA helps to convert your WordPress website into Progressive Web Apps easily.
     <br>
     <br>
-    <a href="https://superpwa.com"><strong>Visit Website »</strong></a>
+    <a href="https://superpwa.com/?utm_source=GitHub&utm_medium=readme-viewWeb"><strong>Visit Website »</strong></a>
     <br>
     <br>
     <a href="https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/new?template=bug.md">Report bug</a>
@@ -57,14 +57,14 @@
 
 ## Welcome to the Super PWA GitHub repository
 
-⚡️ Demo :  <a href="https://superpwa.com/?utm=GitHub">superpwa.com</a>
+⚡️ Demo :  <a href="https://superpwa.com/?utm_source=GitHub&utm_medium=readme-welcome">superpwa.com</a>
 
 ## What is Progressive Web Apps
 Progressive Web Apps (PWA) is a new technology that creates a middle ground between a website and a mobile app. They are installed on the phone like a normal app (web app) and can be accessed from the home screen. 
 
 Users can come back to your website by launching the app from their home screen and interact with your website through an app-like interface. Your return visitors will experience almost-instant loading times and enjoy the great performance benefits of your PWA!
 
-<a href="https://superpwa.com">Super Progressive Web Apps</a> makes it easy for you to convert your WordPress website into a Progressive Web App easily!
+<a href="https://superpwa.com?utm_source=github&utm_medium=readme-what-is-pwa">Super Progressive Web Apps</a> makes it easy for you to convert your WordPress website into a Progressive Web App easily!
 
 ## 🏗 Installation
 Once SuperPWA ⚡️ is installed, users browsing your website from a supported mobile device will see a "Add To Home Screen" notice (from the bottom of the screen) and will be able to 'install your website' on the home screen of their device. Every page visited is stored locally on their device and will be available to read even when they are offline!
@@ -96,7 +96,7 @@ Here are the current features of Super Progressive Web Apps:
 * New in version 1.4: You can now set the theme_color property in the manifest.
 * New in version 1.5: OneSignal integration for Push notifications.
 * New in version 1.6: WordPress Multisite Network compatibility.
-* New in version 1.7: Add-Ons for SuperPWA is here! Ships with [UTM Tracking Add-On](https://superpwa.com/addons/utm-tracking/?utm_source=github&utm_medium=readme) to track visits coming from your PWA.
+* New in version 1.7: Add-Ons for SuperPWA is here! Ships with [UTM Tracking Add-On](https://superpwa.com/addons/utm-tracking/?utm_source=github&utm_medium=readme-version) to track visits coming from your PWA.
 
 #### 🔮 Upcoming features:
 * Offline Indicator Notice.

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,9 @@ PWA's require browsers with support for service workers and for iOS devices, sup
 
 == Changelog ==
 
+= 1.8 =
+* Date: 
+
 = 1.7.1 =
 * Date: 05.May.2018
 * Bug Fix: Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context".

--- a/superpwa.php
+++ b/superpwa.php
@@ -6,7 +6,7 @@
  * Author: SuperPWA
  * Author URI: https://superpwa.com
  * Contributors: Arun Basil Lal, Jose Varghese
- * Version: 1.7.1
+ * Version: 1.8
  * Text Domain: super-progressive-web-apps
  * Domain Path: /languages
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -43,7 +43,7 @@ if ( ! defined('ABSPATH') ) exit;
  * @since 1.6 Depreciated constants for multisite compatibility: SUPERPWA_MANIFEST_FILENAME, SUPERPWA_MANIFEST_ABS, SUPERPWA_MANIFEST_SRC
  * @since 1.6 Depreciated constants for multisite compatibility: SUPERPWA_SW_FILENAME, SUPERPWA_SW_ABS, SUPERPWA_SW_SRC
  */
-if ( ! defined( 'SUPERPWA_VERSION' ) )		define( 'SUPERPWA_VERSION'	, '1.7.1' ); // SuperPWA current version
+if ( ! defined( 'SUPERPWA_VERSION' ) )		define( 'SUPERPWA_VERSION'	, '1.8' ); // SuperPWA current version
 if ( ! defined( 'SUPERPWA_PATH_ABS' ) ) 	define( 'SUPERPWA_PATH_ABS'	, plugin_dir_path( __FILE__ ) ); // Absolute path to the plugin directory. eg - /var/www/html/wp-content/plugins/super-progressive-web-apps/
 if ( ! defined( 'SUPERPWA_PATH_SRC' ) ) 	define( 'SUPERPWA_PATH_SRC'	, plugin_dir_url( __FILE__ ) ); // Link to the plugin folder. eg - http://example.com/wp/wp-content/plugins/super-progressive-web-apps/
 


### PR DESCRIPTION
Comes from here: https://wordpress.org/support/topic/link-to-manually-install-the-pwa/

Maybe it's a good idea to have the possibility to obtain a link to manually install (add to home screen) the pwa (giving the chance to the website owner to put the link anywhere in the site).

PD: first time using github, sorry if this is not the way... also for my poor english.

Regards.