### PR TITLE
Replace substr() by mb_substr()

### DIFF
--- a/admin/admin-ui-setup.php
+++ b/admin/admin-ui-setup.php
@@ -212,7 +212,7 @@ function superpwa_validater_and_sanitizer( $settings ) {
 	$settings['app_name'] = sanitize_text_field( $settings['app_name'] ) == '' ? get_bloginfo( 'name' ) : sanitize_text_field( $settings['app_name'] );
 	
 	// Sanitize Application Short Name
-	$settings['app_short_name'] = substr( sanitize_text_field( $settings['app_short_name'] ) == '' ? get_bloginfo( 'name' ) : sanitize_text_field( $settings['app_short_name'] ), 0, 12 );
+	$settings['app_short_name'] = mb_substr( sanitize_text_field( $settings['app_short_name'] ) == '' ? get_bloginfo( 'name' ) : sanitize_text_field( $settings['app_short_name'] ), 0, 12 );
 	
 	// Sanitize description
 	$settings['description'] = sanitize_text_field( $settings['description'] );


### PR DESCRIPTION
This will allow you to correctly abbreviate names with non-standard characters.

### Example
```php
<?php

$str = "Развивайка"; // 10 characters
$start = 0;
$length = 12;

substr($str, $start, $length); // Развив — wrong  🚫
mb_substr($str, $start, $length); // Развивайка — correct ✅
 
```