### PR TITLE
Add WPML support

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,20 @@
+<wpml-config>
+    <admin-texts>
+        <key name="superpwa_settings">
+            <key name="app_name"/>
+            <key name="app_short_name"/>
+            <key name="description"/>
+            <key name="icon"/>
+            <key name="splash_icon"/>
+            <key name="start_url"/>
+            <key name="offline_page"/>
+        </key>
+        <key name="superpwa_utm_tracking_settings">
+            <key name="utm_source"/>
+            <key name="utm_medium"/>
+            <key name="utm_campaign"/>
+            <key name="utm_term"/>
+            <key name="utm_content"/>
+        </key>
+    </admin-texts>
+</wpml-config>


### PR DESCRIPTION
Hi,

When using the WPML plugin, it can be interesting to have certain elements of the SuperPWA configuration specific to each language of the site.

By adding the wpml-config.xml file, it's done!

Then, just go to the WPML > String Translation menu and filter the domain on "admin_texts_superpwa_settings".

If, in the profile configuration, you have defined "Set admin language as editing language.", Then you just have to change the language in the SuperPWA configuration!