### PR TITLE
Branch 2.1

### DIFF
--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -218,15 +218,14 @@ function superpwa_onesignal_admin_notices() {
 	
 	// Incompatibility notice for Multisites
 	if ( is_multisite() && current_user_can( 'manage_options' ) ) {
+		
 		echo '<div class="notice notice-warning"><p>' . 
-	sprintf( 
-		__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
-		'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
-	) . '</p></div>';
+		sprintf( 
+			__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
+			'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
+		) . '</p></div>';
+		
+		// Filter PWA status since PWA is not ready yet. 
+		add_filter( 'superpwa_is_pwa_ready', '__return_false' );
 	}
-
-	
-	
-	// Filter PWA status since PWA is not ready yet. 
-	add_filter( 'superpwa_is_pwa_ready', '__return_false' );
 }

--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -212,47 +212,21 @@ add_action( 'deactivate_onesignal-free-web-push-notifications/onesignal.php', 's
  * One multisites, warn users that SuperPWA and OneSignal cannot work together. 
  * 
  * @since 1.8.1
+ * @since 2.1 Removed the notice recommending customers to add manifest to OneSignal.
  */
 function superpwa_onesignal_admin_notices() {
 	
-	// Notices only for admins.
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-	
 	// Incompatibility notice for Multisites
-	if ( is_multisite() ) {
-		echo '<div class="notice notice-warning"><p>' . 
-		sprintf( 
-			__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
-			'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
-		) . '</p></div>';
-		
-		// Filter PWA status since PWA is not ready yet. 
-		add_filter( 'superpwa_is_pwa_ready', '__return_false' );
-		
+	if ( ! is_multisite() && ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
+
+	echo '<div class="notice notice-warning"><p>' . 
+	sprintf( 
+		__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
+		'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
+	) . '</p></div>';
 	
-	// Get OneSignal settings.
-	$onesignal_wp_settings = get_option( 'OneSignalWPSetting' );
-	
-	// Show notice if OneSignal custom manifest is disabled or if the custom manifest is not the SuperPWA manifest.
-	if ( 
-		! isset( $onesignal_wp_settings['use_custom_manifest'] ) 			|| 
-		! ( (int) $onesignal_wp_settings['use_custom_manifest'] === 1 )		||
-		! isset( $onesignal_wp_settings['custom_manifest_url'] ) 			|| 
-		! ( strcasecmp( trim( $onesignal_wp_settings['custom_manifest_url'] ), superpwa_manifest( 'src' ) ) === 0  )
-	) {
-		echo '<div class="notice notice-warning"><p>' . 
-		sprintf( 
-			__( '<strong>Action Required to integrate SuperPWA with OneSignal:</strong><br>1. Go to <a href="%s" target="_blank">OneSignal Configuration > Scroll down to Advanced Settings &rarr;</a><br>2. Enable <strong>Use my own manifest.json</strong><br>3. Set <code>%s</code>as <strong>Custom manifest.json URL</strong> and Save Settings.<br>Please refer the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
-			admin_url( 'admin.php?page=onesignal-push#configuration' ), 
-			superpwa_manifest( 'src' ),
-			'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-admin-notice'
-		) . '</p></div>';
-		
-		// Filter PWA status since PWA is not ready yet. 
-		add_filter( 'superpwa_is_pwa_ready', '__return_false' );
-	}
+	// Filter PWA status since PWA is not ready yet. 
+	add_filter( 'superpwa_is_pwa_ready', '__return_false' );
 }

--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -217,15 +217,15 @@ add_action( 'deactivate_onesignal-free-web-push-notifications/onesignal.php', 's
 function superpwa_onesignal_admin_notices() {
 	
 	// Incompatibility notice for Multisites
-	if ( ! is_multisite() && ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-
-	echo '<div class="notice notice-warning"><p>' . 
+	if ( is_multisite() && current_user_can( 'manage_options' ) ) {
+		echo '<div class="notice notice-warning"><p>' . 
 	sprintf( 
 		__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
 		'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
 	) . '</p></div>';
+	}
+
+	
 	
 	// Filter PWA status since PWA is not ready yet. 
 	add_filter( 'superpwa_is_pwa_ready', '__return_false' );

--- a/README.MD
+++ b/README.MD
@@ -217,7 +217,6 @@ There are various ways you can contribute:
 <a href="https://www.youtube.com/channel/UCMFlNeutNCwTNls186moUUA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174883.svg" title="Follow SuperPWA on YouTube" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://www.facebook.com/SuperPWA/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg" title="Follow SuperPWA on Facebook" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://www.instagram.com/superpwa/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174855.svg" title="Follow SuperPWA on Instagram" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://plus.google.com/+SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Follow on Google+" width=35 height=35></a>&nbsp;&nbsp;&nbsp;&nbsp;
 
 * Send us a Pull Request with your bug fixes and/or new features.
 * Provide feedback and [suggestions on enhancements](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open).
@@ -226,7 +225,6 @@ There are various ways you can contribute:
  &nbsp;&nbsp;&nbsp; <a href="https://twitter.com/home?status=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA%20https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/%20%40SuperPWA" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174876.svg" title="Share SuperPWA on Twitter" width=20 height=20> Share on Twitter </a>&nbsp;&nbsp;&nbsp;&nbsp;
 <p> &nbsp;&nbsp;&nbsp; <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174848.svg" title="Follow SuperPWA on Facebook" width=20 height=20> Share on Facebook </a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p> &nbsp;&nbsp;&nbsp; <a href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/&title=Super%20Progressive%20Web%20Apps&summary=Super%20Progressive%20Web%20Apps%20helps%20to%20convert%20your%20WordPress%20website%20into%20PWA%20%23SuperPWA&source=GitHub" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174857.svg" title="Share SuperPWA on LinkedIn" width=20 height=20> Share on LinkedIn</a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
-<p> &nbsp;&nbsp;&nbsp; <a href="https://plus.google.com/share?url=https%3A//github.com/SuperPWA/Super-Progressive-Web-Apps/" target="_blank" style="width:100%"><img src="https://image.flaticon.com/icons/svg/174/174851.svg" title="Share on Google+" width=20 height=20> Share on Google+ </a>&nbsp;&nbsp;&nbsp;&nbsp;</p>
 
 ## 📇 Changelog
 [superpwa.com/changelog/](https://superpwa.com/changelog/?utm_source=GitHub&utm_medium=Readme-Changelog).

--- a/README.MD
+++ b/README.MD
@@ -119,10 +119,10 @@ Here are the current features of Super Progressive Web Apps:
 * New in version 1.5: OneSignal integration for Push notifications.
 * New in version 1.6: WordPress Multisite Network compatibility.
 * New in version 1.7: Add-Ons for SuperPWA is here! Ships with [UTM Tracking Add-On](https://superpwa.com/addons/utm-tracking/?utm_source=GitHub&utm_medium=Readme-version) to track visits coming from your PWA.
-* New in version 1.8: Compatibility issues with OneSignal are now resolved! 
-* New in version 1.8: New Add-On: [Apple Touch Icons](https://superpwa.com/addons/apple-touch-icons/?utm_source=GitHub&utm_medium=Readme-version) that sets your app icons as Apple Touch Icons. 
-* New in version 2.0: SuperPWA is now compatible with WordPress installed in a sub-folder. 
-* New in version 2.0: You can now set [display property](https://superpwa.com/doc/web-app-manifest-display-modes/?utm_source=GitHub&utm_medium=Readme-version) from SuperPWA settings. 
+* New in version 1.8: Compatibility issues with OneSignal are now resolved!
+* New in version 1.8: New Add-On: [Apple Touch Icons](https://superpwa.com/addons/apple-touch-icons/?utm_source=GitHub&utm_medium=Readme-version) that sets your app icons as Apple Touch Icons.
+* New in version 2.0: SuperPWA is now compatible with WordPress installed in a sub-folder.
+* New in version 2.0: You can now set [display property](https://superpwa.com/doc/web-app-manifest-display-modes/?utm_source=GitHub&utm_medium=Readme-version) from SuperPWA settings.
 
 #### 🔮 Upcoming features:
 * Offline Indicator Notice.
@@ -186,7 +186,7 @@ Your Progressive Web App should be ready to test with the default settings upon 
 
 #### Testing Your Progressive Web App
 
-* Open a supported browser in a supported device (for eg: Chrome for Android (62 or higher) in an Android Phone)
+* Open a supported browser in a supported device (for eg: Chrome for Android (62 or higher) in an Android device)
 * Enter your website and wait till it fully loads
 * You should see a pop-up that has your Application Icon and a button that reads "ADD TO HOME SCREEN".
 * Click on it and your PWA will be added to your home screen. Wait for the install to complete. 

--- a/addons/utm-tracking.php
+++ b/addons/utm-tracking.php
@@ -45,6 +45,8 @@ function superpwa_utm_tracking_get_settings() {
 	
 	$defaults = array(
 				'utm_source'		=> 'superpwa',
+				'utm_medium'		=> 'superpwa',
+				'utm_campaign'		=> 'superpwa',
 			);
 	
 	return get_option( 'superpwa_utm_tracking_settings', $defaults );
@@ -207,10 +209,10 @@ function superpwa_utm_tracking_validater_sanitizer( $settings ) {
 	$settings['utm_source'] = sanitize_text_field( $settings['utm_source'] ) == '' ? 'superpwa' : sanitize_text_field( $settings['utm_source'] );
 	
 	// Sanitize campaign medium
-	$settings['utm_medium'] = sanitize_text_field( $settings['utm_medium'] );
+	$settings['utm_medium'] = sanitize_text_field( $settings['utm_medium'] ) == '' ? 'superpwa' : sanitize_text_field( $settings['utm_medium'] );
 	
 	// Sanitize campaign name
-	$settings['utm_campaign'] = sanitize_text_field( $settings['utm_campaign'] );
+	$settings['utm_campaign'] = sanitize_text_field( $settings['utm_campaign'] ) == '' ? 'superpwa' : sanitize_text_field( $settings['utm_campaign'] );
 	
 	// Sanitize campaign term
 	$settings['utm_term'] = sanitize_text_field( $settings['utm_term'] );
@@ -261,7 +263,7 @@ function superpwa_utm_tracking_source_cb() {
 	</fieldset>
 	
 	<p class="description">
-		<?php _e( 'Campaign Source is mandatory and defaults to <code>superpwa</code>. The remaining fields are optional.', 'super-progressive-web-apps' ); ?>
+		<?php _e( 'Campaign Source is mandatory and defaults to <code>superpwa</code>.', 'super-progressive-web-apps' ); ?>
 	</p>
 
 	<?php
@@ -279,9 +281,13 @@ function superpwa_utm_tracking_medium_cb() {
 	
 	<fieldset>
 		
-		<input type="text" name="superpwa_utm_tracking_settings[utm_medium]" placeholder="Optional" class="regular-text" value="<?php if ( isset( $settings['utm_medium'] ) && ( ! empty($settings['utm_medium']) ) ) echo esc_attr( $settings['utm_medium'] ); ?>"/>
+		<input type="text" name="superpwa_utm_tracking_settings[utm_medium]" class="regular-text" value="<?php if ( isset( $settings['utm_medium'] ) && ( ! empty($settings['utm_medium']) ) ) echo esc_attr( $settings['utm_medium'] ); ?>"/>
 		
 	</fieldset>
+	
+	<p class="description">
+		<?php _e( 'Campaign Source is mandatory and defaults to <code>superpwa</code>.', 'super-progressive-web-apps' ); ?>
+	</p>
 
 	<?php
 }
@@ -298,9 +304,13 @@ function superpwa_utm_tracking_name_cb() {
 	
 	<fieldset>
 		
-		<input type="text" name="superpwa_utm_tracking_settings[utm_campaign]" placeholder="Optional" class="regular-text" value="<?php if ( isset( $settings['utm_campaign'] ) && ( ! empty($settings['utm_campaign']) ) ) echo esc_attr( $settings['utm_campaign'] ); ?>"/>
+		<input type="text" name="superpwa_utm_tracking_settings[utm_campaign]" class="regular-text" value="<?php if ( isset( $settings['utm_campaign'] ) && ( ! empty($settings['utm_campaign']) ) ) echo esc_attr( $settings['utm_campaign'] ); ?>"/>
 		
 	</fieldset>
+	
+	<p class="description">
+		<?php _e( 'Campaign Source is mandatory and defaults to <code>superpwa</code>.', 'super-progressive-web-apps' ); ?>
+	</p>
 
 	<?php
 }

--- a/admin/basic-setup.php
+++ b/admin/basic-setup.php
@@ -57,12 +57,23 @@ register_activation_hook( SUPERPWA_PATH_ABS . 'superpwa.php', 'superpwa_activate
  * Will redirect to SuperPWA settings page when plugin is activated.
  * Will not redirect if multiple plugins are activated at the same time.
  * Will not redirect when activated network wide on multisite. Network admins know their way.
+ * 
+ * @param (string) $plugin Path to the main plugin file from plugins directory.
+ * @param (bool) $network_wide True when network activated on multisites. False otherwise. 
+ * 
+ * @author Arun Basil Lal
  *
  * @since 2.0
+ * @since 2.1 Added a check to see if WP_Plugins_List_Table class is available. 
  */
 function superpwa_activation_redirect( $plugin, $network_wide ) {
+	
 	// Return if not SuperPWA or if plugin is activated network wide.
 	if ( $plugin !== plugin_basename( SUPERPWA_PLUGIN_FILE ) || $network_wide === true ) {
+		return false;
+	}
+	
+	if ( ! class_exists( 'WP_Plugins_List_Table' ) ) {
 		return false;
 	}
 
@@ -82,7 +93,6 @@ function superpwa_activation_redirect( $plugin, $network_wide ) {
 	// Redirect to SuperPWA settings page. 
 	exit( wp_redirect( admin_url( 'admin.php?page=superpwa' ) ) );
 }
-
 add_action( 'activated_plugin', 'superpwa_activation_redirect', PHP_INT_MAX, 2 );
 
 /**

--- a/admin/basic-setup.php
+++ b/admin/basic-setup.php
@@ -401,18 +401,22 @@ function superpwa_add_rewrite_rules() {
  * Generates SW and Manifest on the fly.
  *
  * This way no physical files have to be placed on WP root folder. Hallelujah!
- *
- * @since 2.0
+ * 
+ * @author Maria Daniel Deepak <daniel@danieldeepak.com>
  *
  * @uses  superpwa_get_sw_filename()
  * @uses  superpwa_get_manifest_filename()
- * @uses  superpwa_get_manifest()
+ * @uses  superpwa_manifest_template()
+ * @uses  superpwa_sw_template()
+ * 
+ * @since 2.0
+ * @since 2.1 uses http_build_query() instead of implode() to convert query_vars to string.
  */
 function superpwa_generate_sw_and_manifest_on_fly( $query ) {
 	if ( ! property_exists( $query, 'query_vars' ) || ! is_array( $query->query_vars ) ) {
 		return;
 	}
-	$query_vars_as_string = implode( ',', $query->query_vars );
+	$query_vars_as_string = http_build_query( $query->query_vars );
 	$manifest_filename    = superpwa_get_manifest_filename();
 	$sw_filename          = superpwa_get_sw_filename();
 

--- a/languages/super-progressive-web-apps.pot
+++ b/languages/super-progressive-web-apps.pot
@@ -1,17 +1,17 @@
-# Copyright (C) 2019 SuperPWA
+# Copyright (C) 2020 SuperPWA
 # This file is distributed under the same license as the Super Progressive Web Apps plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Super Progressive Web Apps 2.0.1\n"
+"Project-Id-Version: Super Progressive Web Apps 2.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/super-progressive-web-apps\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-01-15T05:23:48+00:00\n"
+"POT-Creation-Date: 2020-05-28T22:12:23+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.1.0\n"
+"X-Generator: WP-CLI 2.2.0\n"
 "X-Domain: super-progressive-web-apps\n"
 
 #. Plugin Name of the plugin
@@ -39,12 +39,8 @@ msgstr ""
 msgid "https://superpwa.com/?utm_source=superpwa-plugin&utm_medium=author-uri"
 msgstr ""
 
-#: 3rd-party/onesignal.php:220
+#: 3rd-party/onesignal.php:224
 msgid "<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href=\"%s\" target=\"_blank\">OneSignal integration documentation</a> for more info. "
-msgstr ""
-
-#: 3rd-party/onesignal.php:242
-msgid "<strong>Action Required to integrate SuperPWA with OneSignal:</strong><br>1. Go to <a href=\"%s\" target=\"_blank\">OneSignal Configuration > Scroll down to Advanced Settings &rarr;</a><br>2. Enable <strong>Use my own manifest.json</strong><br>3. Set <code>%s</code>as <strong>Custom manifest.json URL</strong> and Save Settings.<br>Please refer the <a href=\"%s\" target=\"_blank\">OneSignal integration documentation</a> for more info. "
 msgstr ""
 
 #: addons/utm-tracking.php:35
@@ -52,48 +48,50 @@ msgstr ""
 msgid "UTM Tracking"
 msgstr ""
 
-#: addons/utm-tracking.php:146
+#: addons/utm-tracking.php:148
 msgid "Current Start URL"
 msgstr ""
 
-#: addons/utm-tracking.php:155
+#: addons/utm-tracking.php:157
 msgid "Campaign Source"
 msgstr ""
 
-#: addons/utm-tracking.php:164
+#: addons/utm-tracking.php:166
 msgid "Campaign Medium"
 msgstr ""
 
-#: addons/utm-tracking.php:173
+#: addons/utm-tracking.php:175
 msgid "Campaign Name"
 msgstr ""
 
-#: addons/utm-tracking.php:182
+#: addons/utm-tracking.php:184
 msgid "Campaign Term"
 msgstr ""
 
-#: addons/utm-tracking.php:191
+#: addons/utm-tracking.php:193
 msgid "Campaign Content"
 msgstr ""
 
-#: addons/utm-tracking.php:234
+#: addons/utm-tracking.php:236
 msgid "This add-on automatically adds UTM campaign parameters to the <code>Start Page</code> URL in your <a href=\"%s\" target=\"_blank\">manifest</a>. This will help you identify visitors coming specifically from your app. <a href=\"%s\" target=\"_blank\">Read more</a> about UTM Tracking."
 msgstr ""
 
-#: addons/utm-tracking.php:264
-msgid "Campaign Source is mandatory and defaults to <code>superpwa</code>. The remaining fields are optional."
+#: addons/utm-tracking.php:266
+#: addons/utm-tracking.php:289
+#: addons/utm-tracking.php:312
+msgid "Campaign Source is mandatory and defaults to <code>superpwa</code>."
 msgstr ""
 
-#: addons/utm-tracking.php:362
+#: addons/utm-tracking.php:372
 #: admin/admin-ui-render-settings.php:419
 msgid "Settings saved."
 msgstr ""
 
-#: addons/utm-tracking.php:371
+#: addons/utm-tracking.php:381
 msgid "UTM Tracking for"
 msgstr ""
 
-#: addons/utm-tracking.php:382
+#: addons/utm-tracking.php:392
 #: admin/admin-ui-render-settings.php:442
 msgid "Save Settings"
 msgstr ""
@@ -297,7 +295,7 @@ msgid "Progressive Web Apps require that your website is served over HTTPS. Plea
 msgstr ""
 
 #: admin/admin-ui-setup.php:31
-#: admin/basic-setup.php:337
+#: admin/basic-setup.php:365
 msgid "Settings"
 msgstr ""
 
@@ -365,28 +363,28 @@ msgstr ""
 msgid "HTTPS"
 msgstr ""
 
-#: admin/admin-ui-setup.php:325
+#: admin/admin-ui-setup.php:348
 msgid "If you like SuperPWA, please <a href=\"%s\" target=\"_blank\">make a donation</a> or leave a <a href=\"%s\" target=\"_blank\">&#9733;&#9733;&#9733;&#9733;&#9733;</a> rating to support continued development. Thanks a bunch!"
 msgstr ""
 
-#: admin/basic-setup.php:103
+#: admin/basic-setup.php:113
 msgid "Your app is ready with the default settings. "
 msgstr ""
 
-#: admin/basic-setup.php:107
+#: admin/basic-setup.php:117
 msgid "<a href=\"%s\">Customize your app &rarr;</a>"
 msgstr ""
 
-#: admin/basic-setup.php:109
-#: admin/basic-setup.php:143
+#: admin/basic-setup.php:119
+#: admin/basic-setup.php:153
 msgid "Thank you for installing <strong>Super Progressive Web Apps!</strong> "
 msgstr ""
 
-#: admin/basic-setup.php:118
-#: admin/basic-setup.php:152
+#: admin/basic-setup.php:128
+#: admin/basic-setup.php:162
 msgid "<strong>SuperPWA</strong>: Successfully updated to version %s. Thank you! <a href=\"%s\" target=\"_blank\">Discover new features and read the story &rarr;</a>"
 msgstr ""
 
-#: admin/basic-setup.php:353
+#: admin/basic-setup.php:381
 msgid "Demo"
 msgstr ""

--- a/public/manifest.php
+++ b/public/manifest.php
@@ -311,7 +311,7 @@ function superpwa_get_orientation() {
 /**
  * Get display of PWA
  *
- * @return	string	Display of PWA as set in the plugin settings.
+ * @return (string) Display of PWA as set in the plugin settings.
  * 
  * @author Jose Varghese
  * 
@@ -322,7 +322,7 @@ function superpwa_get_display() {
 	// Get Settings
 	$settings = superpwa_get_settings();
 	
-	$display = isset( $settings['display'] ) ? $settings['display'] : 0;
+	$display = isset( $settings['display'] ) ? $settings['display'] : 1;
 	
 	switch ( $display ) {
 		

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,9 @@ SuperPWA helps you convert your WordPress website into a Progressive Web App ins
 
 == Description ==
 
+> **Help decide on the future of SuperPWA**
+> We are looking for your input to decide on the future of SuperPWA. If you wish to acquire SuperPWA as a whole and continue it's development or if you are interested in a premium version of the plugin with extended features, [please fill in the form and let us know](https://superpwa.com/superpwa-2-1/?utm_source=wordpress.org&utm_medium=description-future). 
+
 Progressive Web Apps (PWA) is a new technology that combines the best of mobile web and the best of mobile apps to create a superior mobile web experience. They are installed on the phone like a normal app (web app) and can be accessed from the home screen. 
 
 Users can come back to your website by launching the app from their home screen and interact with your website through an app-like interface. Your return visitors will experience almost-instant loading times and enjoy the great performance benefits of your PWA!
@@ -179,13 +182,13 @@ Feel free to get in touch if you have any questions.
 == Changelog ==
 
 = 2.1 =
-* Date:
+* Date: [29.May.2020](https://superpwa.com/superpwa-2-1/?utm_source=wordpress.org&utm_medium=changelog)
 * Tested with WordPress 5.4.1.
-* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
-* Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
+* Enhancement: Removed the WordPress admin notice suggesting to add SuperPWA manifest to OneSignal. [#114] (https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/114)
 * Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
 * Enhancement: UTM Tracking Add-on: Added default values for Campaign Medium and Campaign Name.
-* Enhancement: Removed the WordPress admin notice suggesting to add SuperPWA manifest to OneSignal. [#114] (https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/114)
+* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
+* Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
 
 = 2.0.2 =
 * Date: 16.January.2019
@@ -309,6 +312,14 @@ Feel free to get in touch if you have any questions.
 * First release of the plugin.
 
 == Upgrade Notice ==
+
+= 2.1 =
+* Tested with WordPress 5.4.1.
+* Enhancement: Removed the WordPress admin notice suggesting to add SuperPWA manifest to OneSignal. 
+* Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
+* Enhancement: UTM Tracking Add-on: Added default values for Campaign Medium and Campaign Name.
+* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. 
+* Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. 
 
 = 2.0.2 =
 * Bug Fix: Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context". 

--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ Feel free to get in touch if you have any questions.
 * Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
 * Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
 * Enhancement: UTM Tracking Add-on: Added default values for Campaign Medium and Campaign Name.
+* Enhancement: Removed the WordPress admin notice suggesting to add SuperPWA manifest to OneSignal. [#114] (https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/114)
 
 = 2.0.2 =
 * Date: 16.January.2019

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: superpwa, arunbasillal, josevarghese, mariadanieldeepak
 Donate link: http://millionclues.com/donate/
 Tags: pwa, progressive web apps, manifest, web manifest, android app, chrome app, add to homescreen, mobile web
 Requires at least: 3.6.0
-Tested up to: 5.1
+Tested up to: 5.4.1
 Requires PHP: 5.3
 Stable tag: trunk
 License: GPLv2 or later
@@ -180,7 +180,9 @@ Feel free to get in touch if you have any questions.
 
 = 2.1 =
 * Date: 
-* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415
+* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
+* Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
+* Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
 
 = 2.0.2 =
 * Date: 16.January.2019

--- a/readme.txt
+++ b/readme.txt
@@ -183,6 +183,7 @@ Feel free to get in touch if you have any questions.
 * Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
 * Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
 * Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
+* Enhancement: UTM Tracking Add-on: Added default values for Campaign Medium and Campaign Name.
 
 = 2.0.2 =
 * Date: 16.January.2019

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Progressive Web Apps ===
-Contributors: superpwa, arunbasillal, josevarghese, mariadanieldeepak
+Contributors: superpwa, arunbasillal, josevarghese
 Donate link: http://millionclues.com/donate/
 Tags: pwa, progressive web apps, manifest, web manifest, android app, chrome app, add to homescreen, mobile web
 Requires at least: 3.6.0

--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,10 @@ Feel free to get in touch if you have any questions.
 
 == Changelog ==
 
+= 2.1 =
+* Date: 
+* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415
+
 = 2.0.2 =
 * Date: 16.January.2019
 * Bug Fix: Fix fatal error in PHP versions prior to PHP 5.5. "Cant use function return value in write context". 

--- a/readme.txt
+++ b/readme.txt
@@ -179,7 +179,8 @@ Feel free to get in touch if you have any questions.
 == Changelog ==
 
 = 2.1 =
-* Date: 
+* Date:
+* Tested with WordPress 5.4.1.
 * Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
 * Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)
 * Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().

--- a/superpwa.php
+++ b/superpwa.php
@@ -6,7 +6,7 @@
  * Author: SuperPWA
  * Author URI: https://superpwa.com/?utm_source=superpwa-plugin&utm_medium=author-uri
  * Contributors: Arun Basil Lal, Jose Varghese
- * Version: 2.0.2
+ * Version: 2.1
  * Text Domain: super-progressive-web-apps
  * Domain Path: /languages
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -20,7 +20,7 @@
  *
  * /3rd-party/					- Functions for compatibility with 3rd party plugins and hosts.
  * /addons/ 					- Bundled add-ons
- * /admin/						- Plugin backend.
+ * /admin/					- Plugin backend.
  * /functions/					- Functions and utilites.
  * /includes/					- External third party classes and libraries.
  * /languages/					- Translation files go here. 
@@ -43,7 +43,7 @@ if ( ! defined('ABSPATH') ) exit;
  * @since 1.0
  */
 if ( ! defined( 'SUPERPWA_VERSION' ) ) {
-	define( 'SUPERPWA_VERSION'	, '2.0.2' ); 
+	define( 'SUPERPWA_VERSION'	, '2.1' ); 
 }
 
 /**


### PR DESCRIPTION
= 2.1 =
* Date: [29.May.2020](https://superpwa.com/superpwa-2-1/)
* Tested with WordPress 5.4.1.
* Enhancement: Removed the WordPress admin notice suggesting to add SuperPWA manifest to OneSignal. [#114] (https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/114)
* Enhancement: Updated fallback value in superpwa_get_display() to match the default value in superpwa_get_settings().
* Enhancement: UTM Tracking Add-on: Added default values for Campaign Medium and Campaign Name.
* Bug Fix: Fixed a rare PHP Notice: Array to string conversion in basic-setup.php on line 415. [#92](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/92)
* Bug Fix: Added a check to see if WP_Plugins_List_Table class is available before using it. [#93](https://github.com/SuperPWA/Super-Progressive-Web-Apps/issues/93)