### PR TITLE
2.2.33

### DIFF
--- a/addons/apple-touch-icons.php
+++ b/addons/apple-touch-icons.php
@@ -23,45 +23,48 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @since 1.8
  */
 function superpwa_ati_add_apple_touch_icons( $tags ) {
-	
-    // Get the icons added via SuperPWA > Settings
-    //$icons = superpwa_get_pwa_icons();
-        // Get settings
-    $settings = superpwa_get_settings();
 
-    $splashIcons = superpwa_apple_icons_get_settings();
+    if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) {
 
-    if(isset($splashIcons['status_bar_style']) && !empty($splashIcons['status_bar_style'])){
-         $status_bar_style = $splashIcons['status_bar_style'];
-     }else{
-        $status_bar_style = 'default';
-     }
-    $tags .= '<meta name="mobile-web-app-capable" content="yes">' . PHP_EOL;
-    $tags .= '<meta name="apple-touch-fullscreen" content="yes">' . PHP_EOL;
-    $tags .= '<meta name="apple-mobile-web-app-title" content="'.esc_attr($settings['app_name']).'">' . PHP_EOL;
-    $tags .= '<meta name="application-name" content="'.esc_attr($settings['app_name']).'">' . PHP_EOL;
-    $tags .= '<meta name="apple-mobile-web-app-capable" content="yes">' . PHP_EOL;
-    $tags .= '<meta name="apple-mobile-web-app-status-bar-style" content="'.esc_attr($status_bar_style).'">' . PHP_EOL;
+        // Get the icons added via SuperPWA > Settings            
+        $settings = superpwa_get_settings();
 
-    if(isset($settings['icon']) && !empty($settings['icon']))
-    {
-        $tags .= '<link rel="apple-touch-icon"  href="' .esc_url($settings['icon']) . '">' . PHP_EOL; 
-        $tags .= '<link rel="apple-touch-icon" sizes="192x192" href="' .esc_url($settings['icon']) . '">' . PHP_EOL; 
+        $splashIcons = superpwa_apple_icons_get_settings();
+
+        if(isset($splashIcons['status_bar_style']) && !empty($splashIcons['status_bar_style'])){
+            $status_bar_style = $splashIcons['status_bar_style'];
+        }else{
+            $status_bar_style = 'default';
+        }
+        $tags .= '<meta name="mobile-web-app-capable" content="yes">' . PHP_EOL;
+        $tags .= '<meta name="apple-touch-fullscreen" content="yes">' . PHP_EOL;
+        $tags .= '<meta name="apple-mobile-web-app-title" content="'.esc_attr($settings['app_name']).'">' . PHP_EOL;
+        $tags .= '<meta name="application-name" content="'.esc_attr($settings['app_name']).'">' . PHP_EOL;
+        $tags .= '<meta name="apple-mobile-web-app-capable" content="yes">' . PHP_EOL;
+        $tags .= '<meta name="apple-mobile-web-app-status-bar-style" content="'.esc_attr($status_bar_style).'">' . PHP_EOL;
+
+        if(isset($settings['icon']) && !empty($settings['icon']))
+        {
+            $tags .= '<link rel="apple-touch-icon"  href="' .esc_url($settings['icon']) . '">' . PHP_EOL; 
+            $tags .= '<link rel="apple-touch-icon" sizes="192x192" href="' .esc_url($settings['icon']) . '">' . PHP_EOL; 
+        }
+        //Ios splash screen
+        $iosScreenSetting = get_option( 'superpwa_apple_icons_uploaded' );
+        if( $iosScreenSetting && isset($iosScreenSetting['ios_splash_icon']) && !empty($iosScreenSetting['ios_splash_icon']) ) {
+            $iconsInfo = superpwa_apple_splashscreen_files_data();
+            foreach ( $iosScreenSetting['ios_splash_icon'] as $key => $value ) {
+                if( !empty($value) && !empty($key) && isset($iconsInfo[$key]) ) {
+                    $screenData = $iconsInfo[$key];
+                    $tags .= '<link rel="apple-touch-startup-image" media="screen and (device-width: '.esc_attr($screenData['device-width']).') and (device-height: '.esc_attr($screenData['device-height']).') and (-webkit-device-pixel-ratio: '.esc_attr($screenData['ratio']).') and (orientation: '.esc_attr($screenData['orientation']).')" href="'.esc_url($value).'"/>'."\n";
+                }//if closed
+            }//foreach closed
+        }
+
     }
-    //Ios splash screen
-    $iosScreenSetting = get_option( 'superpwa_apple_icons_uploaded' );
-    if( $iosScreenSetting && isset($iosScreenSetting['ios_splash_icon']) && !empty($iosScreenSetting['ios_splash_icon']) ) {
-        $iconsInfo = superpwa_apple_splashscreen_files_data();
-        foreach ( $iosScreenSetting['ios_splash_icon'] as $key => $value ) {
-            if( !empty($value) && !empty($key) && isset($iconsInfo[$key]) ) {
-                $screenData = $iconsInfo[$key];
-                $tags .= '<link rel="apple-touch-startup-image" media="screen and (device-width: '.esc_attr($screenData['device-width']).') and (device-height: '.esc_attr($screenData['device-height']).') and (-webkit-device-pixel-ratio: '.esc_attr($screenData['ratio']).') and (orientation: '.esc_attr($screenData['orientation']).')" href="'.esc_url($value).'"/>'."\n";
-            }//if closed
-        }//foreach closed
-    }
-
+	    
     return $tags;
 }
+
 add_filter( 'superpwa_wp_head_tags', 'superpwa_ati_add_apple_touch_icons' );
 
 /**
@@ -73,17 +76,28 @@ add_filter( 'superpwa_wp_head_tags', 'superpwa_ati_add_apple_touch_icons' );
  * 
  * @return (string) Remove the Apple Touch Icons from the existing tag string
  */
-function superpwa_remove_site_apple_touch_icon($meta_tags) {
-	if(is_customize_preview() && is_admin()){
+function superpwa_remove_site_apple_touch_icon( $meta_tags ) {
+
+    if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) {
+
+        if ( is_customize_preview() && is_admin() ) {
             return $meta_tags;
         }
-        foreach ($meta_tags as $key => $value) {
-            if(strpos($value, 'apple-touch-icon') !== false){
-                unset($meta_tags[$key]);
+
+        foreach ( $meta_tags as $key => $value ) {
+
+            if ( strpos( $value, 'apple-touch-icon' ) !== false ) {
+
+                unset( $meta_tags[$key] );
+
             }
         }
-        return $meta_tags;
+
+    }
+	
+    return $meta_tags;
 }
+
 add_filter( 'site_icon_meta_tags', 'superpwa_remove_site_apple_touch_icon', 0 );
 
 
@@ -108,7 +122,10 @@ function superpwa_apple_icons_get_settings() {
  * @since 	2.1.7
  */
 function superpwa_apple_icons_register_settings() {
-    // Register Setting
+
+    if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) {
+
+        // Register Setting
 	register_setting( 
 		'superpwa_apple_icons_settings_group',		 // Group name
 		'superpwa_apple_icons_settings', 			// Setting name = html form <input> name on settings form
@@ -155,6 +172,9 @@ function superpwa_apple_icons_register_settings() {
             'superpwa_apple_icons_section',                      // Page slug
             'superpwa_apple_icons_section'                       // Settings Section ID
         );
+
+    }
+    
 }
 add_action( 'admin_init', 'superpwa_apple_icons_register_settings' );
 
@@ -277,21 +297,26 @@ function superpwa_apple_splashscreen_files_data(){
     return $iosSplashData;
 }
 
-function superpwa_load_admin_scripts($hooks){
-    if( !in_array($hooks, array('superpwa_page_superpwa-apple-icons', 'super-pwa_page_superpwa-apple-icons')) && strpos($hooks, 'superpwa-apple-icons') == false ) {
-        return false;
+function superpwa_load_admin_scripts( $hooks ){
+
+    if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) {
+
+        if( !in_array($hooks, array('superpwa_page_superpwa-apple-icons', 'super-pwa_page_superpwa-apple-icons')) && strpos($hooks, 'superpwa-apple-icons') == false ) {
+            return false;
+        }
+        wp_enqueue_media();
+        wp_register_script('superpwa-admin-apple-script',SUPERPWA_PATH_SRC .'/admin/js/jszip.min.js', array('superpwa-main-js'), SUPERPWA_VERSION, true);
+        wp_enqueue_script('superpwa-admin-apple-script'); 
+        wp_localize_script( 'superpwa-admin-apple-script', 'superpwaIosScreen', 
+                            array(
+                                'nonce'=> wp_create_nonce( 'superpwaIosScreenSecurity' ),
+                                'max_file_size'=> ini_get('upload_max_filesize')
+                            ) );
+
     }
-    wp_enqueue_media();
-    wp_register_script('superpwa-admin-apple-script',SUPERPWA_PATH_SRC .'/admin/js/jszip.min.js', array('superpwa-main-js'), SUPERPWA_VERSION, true);
-    wp_enqueue_script('superpwa-admin-apple-script'); 
-    wp_localize_script( 'superpwa-admin-apple-script', 'superpwaIosScreen', 
-                        array(
-                            'nonce'=> wp_create_nonce( 'superpwaIosScreenSecurity' ),
-                            'max_file_size'=> ini_get('upload_max_filesize')
-                        ) );
-
-
+    
 }
+
 add_action( 'admin_enqueue_scripts', 'superpwa_load_admin_scripts' );
 
 /**
@@ -318,8 +343,10 @@ function superpwa_apple_icons_validater_sanitizer( $settings ) {
  * @since 1.7
  */ 
 function superpwa_apple_icons_interface_render() {
-	
-	// Authentication
+
+	if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ){
+
+        // Authentication
     if ( ! current_user_can( superpwa_current_user_can() ) ) {
         return;
     }
@@ -362,66 +389,73 @@ function superpwa_apple_icons_interface_render() {
 	</div>
     <?php superpwa_newsletter_form(); ?>
 	<?php
+
+    }
+	
 }
 
 function superpwa_splashscreen_uploader(){
 
-    // Authentication
-    if ( ! current_user_can( 'manage_options' ) ) {
-       return;
-    }
+    if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) {
 
-    if( (!isset($_POST['security_nonce'])) || (isset($_POST['security_nonce']) && !wp_verify_nonce( $_POST['security_nonce'], 'superpwaIosScreenSecurity' )) ) {
-        echo wp_json_encode(array('status'=>400, 'message'=>esc_html__('security nonce not matched','super-progressive-web-apps')));die;
+        // Authentication
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+    
+        if( (!isset($_POST['security_nonce'])) || (isset($_POST['security_nonce']) && !wp_verify_nonce( $_POST['security_nonce'], 'superpwaIosScreenSecurity' )) ) {
+            echo wp_json_encode(array('status'=>400, 'message'=>esc_html__('security nonce not matched','super-progressive-web-apps')));die;
+        }
+        
+        if(isset($_FILES['file']['type']) && $_FILES['file']['type']!='application/zip'){
+            echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('file type not matched','super-progressive-web-apps')));die;
+        }
+        if(isset($_FILES['file']['error']) && $_FILES['file']['error']!='0'){
+            echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('file contains error','super-progressive-web-apps')));die;
+        }
+    
+        $upload = wp_upload_dir();
+        $path =  $upload['basedir']."/superpwa-splashIcons/";
+        $subpath = $upload['basedir']."/superpwa-splashIcons/super_splash_screens/";
+        wp_mkdir_p($path);
+    
+        if ( ! function_exists( 'wp_filesystem' ) ) {
+            require_once( ABSPATH . 'wp-admin/includes/file.php' );
+        }
+        
+        // Initialize the WP_Filesystem global variable
+        global $wp_filesystem;
+        
+        if ( ! WP_Filesystem() ) {
+            WP_Filesystem();
+        }
+        
+        $wp_filesystem->put_contents( $path . '/index.html', '', FS_CHMOD_FILE ); // FS_CHMOD_FILE is the default file permission
+        $wp_filesystem->put_contents( $subpath . '/index.html', '', FS_CHMOD_FILE );
+        
+        $zipFileName = $path."/splashScreen.zip";
+        // phpcs:ignore Generic.PHP.ForbiddenFunctions.Found
+        $moveFile = move_uploaded_file($_FILES['file']['tmp_name'], $zipFileName);
+    
+        if($moveFile && superpwa_zip_allowed_extensions($zipFileName,['png'])){
+            $result = unzip_file($zipFileName, $path);
+            wp_delete_file($zipFileName);    
+        }else{
+            echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('Files are not uploading','super-progressive-web-apps')));die;
+        }
+    
+        $pathURL = $upload['baseurl']."/superpwa-splashIcons/super_splash_screens/";
+        $iosScreenData = superpwa_apple_splashscreen_files_data(); 
+        $iosScreenSetting = (array)get_option( 'superpwa_apple_icons_uploaded' ) ;
+        foreach ($iosScreenData as $key => $value) {
+            $iosScreenSetting['ios_splash_icon'][$key] = sanitize_url($pathURL.$value['file']);
+        }
+        update_option( 'superpwa_apple_icons_uploaded', $iosScreenSetting ) ;
+        
+        echo wp_json_encode(array("status"=>200, "message"=> esc_html__('Splash screen uploaded successfully','super-progressive-web-apps')));
+        die;
     }
     
-    if(isset($_FILES['file']['type']) && $_FILES['file']['type']!='application/zip'){
-        echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('file type not matched','super-progressive-web-apps')));die;
-    }
-    if(isset($_FILES['file']['error']) && $_FILES['file']['error']!='0'){
-        echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('file contains error','super-progressive-web-apps')));die;
-    }
-
-    $upload = wp_upload_dir();
-    $path =  $upload['basedir']."/superpwa-splashIcons/";
-    $subpath = $upload['basedir']."/superpwa-splashIcons/super_splash_screens/";
-    wp_mkdir_p($path);
-
-    if ( ! function_exists( 'wp_filesystem' ) ) {
-        require_once( ABSPATH . 'wp-admin/includes/file.php' );
-    }
-    
-    // Initialize the WP_Filesystem global variable
-    global $wp_filesystem;
-    
-    if ( ! WP_Filesystem() ) {
-        WP_Filesystem();
-    }
-    
-    $wp_filesystem->put_contents( $path . '/index.html', '', FS_CHMOD_FILE ); // FS_CHMOD_FILE is the default file permission
-    $wp_filesystem->put_contents( $subpath . '/index.html', '', FS_CHMOD_FILE );
-    
-    $zipFileName = $path."/splashScreen.zip";
-    // phpcs:ignore Generic.PHP.ForbiddenFunctions.Found
-    $moveFile = move_uploaded_file($_FILES['file']['tmp_name'], $zipFileName);
-
-    if($moveFile && superpwa_zip_allowed_extensions($zipFileName,['png'])){
-        $result = unzip_file($zipFileName, $path);
-        wp_delete_file($zipFileName);    
-    }else{
-        echo wp_json_encode(array('status'=>500, 'message'=>esc_html__('Files are not uploading','super-progressive-web-apps')));die;
-    }
-
-    $pathURL = $upload['baseurl']."/superpwa-splashIcons/super_splash_screens/";
-    $iosScreenData = superpwa_apple_splashscreen_files_data(); 
-    $iosScreenSetting = (array)get_option( 'superpwa_apple_icons_uploaded' ) ;
-    foreach ($iosScreenData as $key => $value) {
-         $iosScreenSetting['ios_splash_icon'][$key] = sanitize_url($pathURL.$value['file']);
-    }
-    update_option( 'superpwa_apple_icons_uploaded', $iosScreenSetting ) ;
-	
-	echo wp_json_encode(array("status"=>200, "message"=> esc_html__('Splash screen uploaded successfully','super-progressive-web-apps')));
-	 	  die;
 }
 function superpwa_zip_allowed_extensions($zip_path, array $allowed_extensions) {
     $zip = new ZipArchive;

--- a/addons/caching-strategies.php
+++ b/addons/caching-strategies.php
@@ -30,74 +30,93 @@ function superpwa_caching_strategies_get_settings() {
 	return get_option( 'superpwa_caching_strategies_settings', $defaults );
 }
 
-function superpwa_caching_strategies_sw_template($file_string){
-	$settings = superpwa_caching_strategies_get_settings();
-	$caching_type = isset($settings['caching_type'])? $settings['caching_type'] : 'network_first';
-	if($caching_type=='network_first'){ return $file_string; }
-	$script = '';
-	switch($caching_type){
-		case 'network_first':
-			$script = ''; //already working with network first, so no need to edit
-			break;
-		case 'cache_first':
-			$script	= 	'e.respondWith(
+function superpwa_caching_strategies_sw_template( $file_string ) {
+
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
+
+		$settings     = superpwa_caching_strategies_get_settings();
+		$caching_type = isset( $settings['caching_type'] ) ? $settings['caching_type'] : 'network_first';
+
+		if ( $caching_type=='network_first' ) {
+			 return $file_string; 
+		}
+		$script = '';
+
+		switch( $caching_type ) {
+
+			case 'network_first':
+				$script = ''; //already working with network first, so no need to edit
+				break;
+
+			case 'cache_first':
+				$script	= 	'e.respondWith(
+					caches.open(cacheName)
+						.then(function(cache) {
+							return cache.match(e.request)
+								.then( function(cacheResponse) {
+										return cacheResponse || fetch(e.request.url).then(function(networkResponse) {
+												cache.put(e.request, networkResponse.clone())
+												return networkResponse;
+											})
+								})
+						}).catch(function(){
+							return fetch(e.request.url).then(function(response) {
+								return caches.open(cacheName).then(function(cache) {
+									cache.put(e.request, response.clone());
+									return response;
+								});  
+							})
+						})
+			);';
+				break;
+			case 'steal_while_revalidate':
+
+				$script = 'e.respondWith(
 				caches.open(cacheName)
 					.then(function(cache) {
-						return cache.match(e.request)
+						cache.match(e.request)
 							.then( function(cacheResponse) {
-									return cacheResponse || fetch(e.request.url).then(function(networkResponse) {
-											cache.put(e.request, networkResponse.clone())
-											return networkResponse;
-										})
+								fetch(e.request)
+									.then(function(networkResponse) {
+										cache.put(e.request, networkResponse)
+									})
+								return cacheResponse || networkResponse
 							})
-					}).catch(function(){
-						return fetch(e.request.url).then(function(response) {
-							return caches.open(cacheName).then(function(cache) {
-								cache.put(e.request, response.clone());
-								return response;
-							});  
-						})
 					})
-		);';
-			break;
-		case 'steal_while_revalidate':
-			$script = 'e.respondWith(
-			caches.open(cacheName)
-				.then(function(cache) {
-					cache.match(e.request)
-						.then( function(cacheResponse) {
-							fetch(e.request)
-								.then(function(networkResponse) {
-									cache.put(e.request, networkResponse)
+			);';
+				break;
+			case 'cache_only':
+
+				$script = 	'e.respondWith(
+				caches.open(cacheName).then(function(cache) {
+					cache.match(e.request).then(function(cacheResponse) {
+						return cacheResponse;
+					})
+				})
+			);';
+				break;
+			case 'network_only':
+
+				$script = 	'e.respondWith(
+								fetch(e.request).then(function(networkResponse) {
+									return networkResponse
 								})
-							return cacheResponse || networkResponse
-						})
-				})
-		);';
-			break;
-		case 'cache_only':
-			$script = 	'e.respondWith(
-			caches.open(cacheName).then(function(cache) {
-				cache.match(e.request).then(function(cacheResponse) {
-					return cacheResponse;
-				})
-			})
-		);';
-			break;
-		case 'network_only':
-			$script = 	'e.respondWith(
-							fetch(e.request).then(function(networkResponse) {
-								return networkResponse
-							})
-						);';
-			break;
+							);';
+				break;
+		}
+		if ( ! empty( $script ) ) {
+
+			$replace_preg="/\/\/strategy_replace_start((.|\n|\t)*?)\/\/strategy_replace_end/i";
+			$file_string = preg_replace( $replace_preg, $script, $file_string );
+
+		}
+
 	}
-	if(!empty($script)){
-		$replace_preg="/\/\/strategy_replace_start((.|\n|\t)*?)\/\/strategy_replace_end/i";
-		$file_string = preg_replace($replace_preg, $script, $file_string);
-	}
+	
     return $file_string;
+
 }
+
 add_filter( 'superpwa_sw_template', 'superpwa_caching_strategies_sw_template', 10, 1 );
 
 
@@ -107,29 +126,34 @@ add_filter( 'superpwa_sw_template', 'superpwa_caching_strategies_sw_template', 1
  */
 function superpwa_pre_caching_urls_sw( $files_to_cache ) {
 	
-	$settings = superpwa_caching_strategies_get_settings();
-	$pre_cache_urls = $manual_urls = '';
-	if(isset($settings['precaching_manual']) && $settings['precaching_manual'] == '1' && !empty($settings['precaching_urls'])){
-		$removing_nl_br = preg_replace( "/\r|\n/", "", $settings['precaching_urls']);
-		$manual_urls = str_replace(',', '\',\'', $removing_nl_br);
-		$files_to_cache = '\''.$manual_urls.'\','.$files_to_cache;
-	}
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
 
+		$settings = superpwa_caching_strategies_get_settings();
+		$pre_cache_urls = $manual_urls = '';
+		
+		if(isset($settings['precaching_manual']) && $settings['precaching_manual'] == '1' && !empty($settings['precaching_urls'])){
+			$removing_nl_br = preg_replace( "/\r|\n/", "", $settings['precaching_urls']);
+			$manual_urls = str_replace(',', '\',\'', $removing_nl_br);
+			$files_to_cache = '\''.$manual_urls.'\','.$files_to_cache;
+		}
 
 	     $store_post_id = array();
          $store_post_id = json_decode(get_transient('superpwa_pre_cache_post_ids'));
                 
-            if(!empty($store_post_id) && isset($settings['precaching_automatic']) && $settings['precaching_automatic']==1){
-                    $files_to_cache .= ',';
-                    foreach ($store_post_id as $post_id){
-                        
-                       $files_to_cache .= "'".trim(get_permalink($post_id))."',\n"; 
-                                                                                                                                            
-                    }
-            }
-	
+		if(!empty($store_post_id) && isset($settings['precaching_automatic']) && $settings['precaching_automatic']==1){
+				$files_to_cache .= ',';
+				foreach ($store_post_id as $post_id){
+					
+					$files_to_cache .= "'".trim(get_permalink($post_id))."',\n"; 
+																																		
+				}
+		}
+
+	}		
+
 	return $files_to_cache;
 }
+
 add_filter( 'superpwa_sw_files_to_cache', 'superpwa_pre_caching_urls_sw' );
 
 /**
@@ -140,61 +164,65 @@ add_filter( 'superpwa_sw_files_to_cache', 'superpwa_pre_caching_urls_sw' );
 add_action( 'publish_post', 'superpwa_store_latest_post_ids', 10, 2 );
 add_action( 'publish_page', 'superpwa_store_latest_post_ids', 10, 2 );
 
- function superpwa_store_latest_post_ids(){
-       
-       if ( ! current_user_can( 'edit_posts' ) ) {
-             return;
-       }
-       
-       $post_ids = array();           
-       $settings = superpwa_caching_strategies_get_settings();
-       
-       if(isset($settings['precaching_automatic']) && $settings['precaching_automatic']==1){
-       
-            $post_count = 10;
-            
-            if(isset($settings['precaching_post_count']) && $settings['precaching_post_count'] !=''){
-               $post_count =$settings['precaching_post_count']; 
-            }                
-            $post_args = array( 'numberposts' => $post_count, 'post_status'=> 'publish', 'post_type'=> 'post'  );                      
-            $page_args = array( 'number'       => $post_count, 'post_status'=> 'publish', 'post_type'=> 'page' );
-                                    
-            if(isset($settings['precaching_automatic_post']) && $settings['precaching_automatic_post']==1){
-                $postslist = get_posts( $post_args );
-                if($postslist){
-                    foreach ($postslist as $post){
-                     $post_ids[] = $post->ID;
-                   }
-                }
-            }else{
-                 delete_transient('superpwa_pre_cache_post_ids');
-            }
-            
-            if(isset($settings['precaching_automatic_page']) && $settings['precaching_automatic_page']==1){
-                $pageslist = get_pages( $page_args );
-                if($pageslist){
-                    foreach ($pageslist as $post){
-                     $post_ids[] = $post->ID;
-                   }               
-                }         
-            }else{
-            	delete_transient('superpwa_pre_cache_post_ids');
-            }   
-            $previousIds = get_transient('superpwa_pre_cache_post_ids');
-            if($post_ids){
-                if($previousIds){
-                    $previousIds = json_decode($previousIds);
-                    if(array_diff($post_ids, $previousIds)){
-                        set_transient('superpwa_pre_cache_post_ids', wp_json_encode($post_ids));
-                    }
-                }else{
-                    set_transient('superpwa_pre_cache_post_ids', wp_json_encode($post_ids));
-                }
-            }
+function superpwa_store_latest_post_ids(){
 
-                          
-       }                                  
-    }
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
+
+	  if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+	  }
+	  
+	  $post_ids = array();           
+	  $settings = superpwa_caching_strategies_get_settings();
+	  
+	  if(isset($settings['precaching_automatic']) && $settings['precaching_automatic']==1){
+	  
+		   $post_count = 10;
+		   
+		   if(isset($settings['precaching_post_count']) && $settings['precaching_post_count'] !=''){
+			  $post_count =$settings['precaching_post_count']; 
+		   }                
+		   $post_args = array( 'numberposts' => $post_count, 'post_status'=> 'publish', 'post_type'=> 'post'  );                      
+		   $page_args = array( 'number'       => $post_count, 'post_status'=> 'publish', 'post_type'=> 'page' );
+								   
+		   if(isset($settings['precaching_automatic_post']) && $settings['precaching_automatic_post']==1){
+			   $postslist = get_posts( $post_args );
+			   if($postslist){
+				   foreach ($postslist as $post){
+					$post_ids[] = $post->ID;
+				  }
+			   }
+		   }else{
+				delete_transient('superpwa_pre_cache_post_ids');
+		   }
+		   
+		   if(isset($settings['precaching_automatic_page']) && $settings['precaching_automatic_page']==1){
+			   $pageslist = get_pages( $page_args );
+			   if($pageslist){
+				   foreach ($pageslist as $post){
+					$post_ids[] = $post->ID;
+				  }               
+			   }         
+		   }else{
+			   delete_transient('superpwa_pre_cache_post_ids');
+		   }   
+		   $previousIds = get_transient('superpwa_pre_cache_post_ids');
+		   if($post_ids){
+			   if($previousIds){
+				   $previousIds = json_decode($previousIds);
+				   if(array_diff($post_ids, $previousIds)){
+					   set_transient('superpwa_pre_cache_post_ids', wp_json_encode($post_ids));
+				   }
+			   }else{
+				   set_transient('superpwa_pre_cache_post_ids', wp_json_encode($post_ids));
+			   }
+		   }
+						 
+	  }
+
+	}
+                                                
+}
 
 /**
  * Todo list after saving caching_strategies settings
@@ -206,9 +234,13 @@ add_action( 'publish_page', 'superpwa_store_latest_post_ids', 10, 2 );
  */
 function superpwa_caching_strategies_save_settings_todo() {
 
-	// Regenerate manifest
-	superpwa_generate_sw();
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) { 
+		// Regenerate manifest
+		superpwa_generate_sw();
+	}
+	
 }
+
 add_action( 'add_option_superpwa_caching_strategies_settings', 'superpwa_caching_strategies_save_settings_todo' );
 add_action( 'update_option_superpwa_caching_strategies_settings', 'superpwa_caching_strategies_save_settings_todo' );
 add_action( 'superpwa_addon_activated_caching_strategies', 'superpwa_caching_strategies_save_settings_todo' );
@@ -221,13 +253,19 @@ add_action( 'superpwa_addon_activated_caching_strategies', 'superpwa_caching_str
  * @since 1.7
  */
 function superpwa_caching_strategies_deactivate_todo() {
-	
-	// Unhook the UTM tracking params filter
-	remove_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url' );
-	
-	// Regenerate Service Worker
-	superpwa_generate_sw();
+
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
+
+		// Unhook the UTM tracking params filter
+		remove_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url' );
+		
+		// Regenerate Service Worker
+		superpwa_generate_sw();
+		
+	}
+		
 }
+
 add_action( 'superpwa_addon_deactivated_caching_strategies', 'superpwa_caching_strategies_deactivate_todo' );
 
 /**
@@ -236,20 +274,23 @@ add_action( 'superpwa_addon_deactivated_caching_strategies', 'superpwa_caching_s
  * @since 	2.1.7
  */
 function superpwa_caching_strategies_settings(){
-    // Register Setting
-	register_setting( 
-		'superpwa_caching_strategies_settings_group',		 // Group name
-		'superpwa_caching_strategies_settings', 			// Setting name = html form <input> name on settings form
-		'superpwa_caching_strategies_validater_sanitizer'	// Input validator and sanitizer
-	);
 
-    // UTM Tracking
-    add_settings_section(
-        'superpwa_caching_strategies_section',				// ID
-        __return_false(),								// Title
-        'superpwa_caching_strategies_section_cb',				// Callback Function
-        'superpwa_caching_strategies_section'					// Page slug
-    );
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
+
+		// Register Setting
+		register_setting( 
+			'superpwa_caching_strategies_settings_group',		 // Group name
+			'superpwa_caching_strategies_settings', 			// Setting name = html form <input> name on settings form
+			'superpwa_caching_strategies_validater_sanitizer'	// Input validator and sanitizer
+		);
+
+		// UTM Tracking
+		add_settings_section(
+			'superpwa_caching_strategies_section',				// ID
+			__return_false(),								// Title
+			'superpwa_caching_strategies_section_cb',				// Callback Function
+			'superpwa_caching_strategies_section'					// Page slug
+		);
         // Caching Strategies type
 		add_settings_field(
 			'superpwa_caching_strategies_caching_type',						// ID
@@ -266,7 +307,11 @@ function superpwa_caching_strategies_settings(){
 			'superpwa_caching_strategies_section',						// Page slug
 			'superpwa_caching_strategies_section'							// Settings Section ID
 		);
+
+	}
+    
 }
+
 add_action( 'admin_init', 'superpwa_caching_strategies_settings' );
 
 
@@ -397,16 +442,22 @@ function superpwa_caching_strategies_pre_caching_cb() {
  */ 
 
 function superpwa_precache_load_admin_scripts($hooks){
-    if( !in_array($hooks, array('superpwa_page_superpwa-caching-strategies', 'super-pwa_page_superpwa-caching-strategies')) && strpos($hooks, 'superpwa-caching-strategies') == false ) {
-        return false;
-    }
-	$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-    wp_register_script('superpwa-admin-precache-script',SUPERPWA_PATH_SRC .'/admin/js/pre-cache'. $suffix .'.js', array('superpwa-main-js'), SUPERPWA_VERSION, true);
-    
-    wp_enqueue_script('superpwa-admin-precache-script'); 
+	if ( superpwa_addons_status( 'caching_strategies' ) 	== 'active' ) {
+
+		if( !in_array($hooks, array('superpwa_page_superpwa-caching-strategies', 'super-pwa_page_superpwa-caching-strategies')) && strpos($hooks, 'superpwa-caching-strategies') == false ) {
+			return false;
+		}
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	
+		wp_register_script('superpwa-admin-precache-script',SUPERPWA_PATH_SRC .'/admin/js/pre-cache'. $suffix .'.js', array('superpwa-main-js'), SUPERPWA_VERSION, true);
+		
+		wp_enqueue_script('superpwa-admin-precache-script'); 
+
+	}
 
 }
+
 add_action( 'admin_enqueue_scripts', 'superpwa_precache_load_admin_scripts' );
 
 /**
@@ -415,46 +466,51 @@ add_action( 'admin_enqueue_scripts', 'superpwa_precache_load_admin_scripts' );
  * @since 2.1.7
  */ 
 function superpwa_caching_strategies_interface_render() {
-	
-	// Authentication
-	if ( ! current_user_can( superpwa_current_user_can() ) ) {
-        return;
-    }
-	
-	// Handing save settings
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-	if ( isset( $_GET['settings-updated'] ) ) {
+
+	if ( superpwa_addons_status( 'caching_strategies' ) == 'active' ) {
+
+		// Authentication
+		if ( ! current_user_can( superpwa_current_user_can() ) ) {
+			return;
+		}
 		
-		// Add settings saved message with the class of "updated"
-		add_settings_error( 'superpwa_settings_group', 'superpwa_caching_strategies_settings_saved_message', __( 'Settings saved.', 'super-progressive-web-apps' ), 'updated' );
+		// Handing save settings
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['settings-updated'] ) ) {
+			
+			// Add settings saved message with the class of "updated"
+			add_settings_error( 'superpwa_settings_group', 'superpwa_caching_strategies_settings_saved_message', __( 'Settings saved.', 'super-progressive-web-apps' ), 'updated' );
+			
+			// Show Settings Saved Message
+			settings_errors( 'superpwa_settings_group' );
+		}
+		// Get add-on info
+		$addon_utm_tracking = superpwa_get_addons( 'caching_strategies' );
+
+		superpwa_setting_tabs_styles();
+		?>
 		
-		// Show Settings Saved Message
-		settings_errors( 'superpwa_settings_group' );
+		<div class="wrap">	
+			<h1><?php esc_html_e( 'Caching Strategies', 'super-progressive-web-apps' ); ?> <small>(<a href="<?php echo esc_url($addon_utm_tracking['link']) . '?utm_source=superpwa-plugin&utm_medium=utm-tracking-settings'?>"><?php echo esc_html__( 'Docs', 'super-progressive-web-apps' ); ?></a>)</small></h1>
+			
+			<?php superpwa_setting_tabs_html(); ?>
+
+			<form action="<?php echo esc_url(admin_url("options.php")); ?>" method="post" class="form-table" enctype="multipart/form-data">		
+				<?php
+				// Output nonce, action, and option_page fields for a settings page.
+				settings_fields( 'superpwa_caching_strategies_settings_group' );
+				
+				// Status
+				do_settings_sections( 'superpwa_caching_strategies_section' );	// Page slug
+				
+				// Output save settings button
+				submit_button( __('Save Settings', 'super-progressive-web-apps') );
+				?>
+			</form>
+		</div>
+		<?php superpwa_newsletter_form(); ?>
+		<?php
+
 	}
-	// Get add-on info
-	$addon_utm_tracking = superpwa_get_addons( 'caching_strategies' );
-
-	superpwa_setting_tabs_styles();
-	?>
-	
-	<div class="wrap">	
-		<h1><?php esc_html_e( 'Caching Strategies', 'super-progressive-web-apps' ); ?> <small>(<a href="<?php echo esc_url($addon_utm_tracking['link']) . '?utm_source=superpwa-plugin&utm_medium=utm-tracking-settings'?>"><?php echo esc_html__( 'Docs', 'super-progressive-web-apps' ); ?></a>)</small></h1>
 		
-		<?php superpwa_setting_tabs_html(); ?>
-
-		<form action="<?php echo esc_url(admin_url("options.php")); ?>" method="post" class="form-table" enctype="multipart/form-data">		
-			<?php
-			// Output nonce, action, and option_page fields for a settings page.
-			settings_fields( 'superpwa_caching_strategies_settings_group' );
-			
-			// Status
-			do_settings_sections( 'superpwa_caching_strategies_section' );	// Page slug
-			
-			// Output save settings button
-			submit_button( __('Save Settings', 'super-progressive-web-apps') );
-			?>
-		</form>
-	</div>
-	<?php superpwa_newsletter_form(); ?>
-	<?php
 }

--- a/addons/pull-to-refresh.php
+++ b/addons/pull-to-refresh.php
@@ -54,12 +54,15 @@ function superpwa_pull_to_refresh_get_settings()
  *
  * @since	1.7
  */
-	function superpwa_pull_to_refresh_save_settings_todo()
-	{
-
-		// Regenerate manifest
-		superpwa_generate_manifest();
+	function superpwa_pull_to_refresh_save_settings_todo(){
+	
+		if ( superpwa_addons_status( 'pull_to_refresh' ) 	== 'active' ) {
+			// Regenerate manifest
+			superpwa_generate_manifest();
+		}
+		
 	}
+
 	add_action('add_option_superpwa_pull_to_refresh_settings', 'superpwa_pull_to_refresh_save_settings_todo');
 	add_action('update_option_superpwa_pull_to_refresh_settings', 'superpwa_pull_to_refresh_save_settings_todo');
 	add_action('superpwa_addon_activated_pull_to_refresh', 'superpwa_pull_to_refresh_save_settings_todo');
@@ -69,79 +72,84 @@ function superpwa_pull_to_refresh_get_settings()
  *
  * @since 	1.7
  */
-	function superpwa_pull_to_refresh_register_settings()
-	{
+	function superpwa_pull_to_refresh_register_settings() {
+	
+		if ( superpwa_addons_status( 'pull_to_refresh' ) 	== 'active' ) {
 
-		// Register Setting
-		register_setting(
-			'superpwa_pull_to_refresh_settings_group',		 // Group name
-			'superpwa_pull_to_refresh_settings', 			// Setting name = html form <input> name on settings form
-			'superpwa_pull_to_refresh_validater_sanitizer'	// Input validator and sanitizer
-		);
+			// Register Setting
+			register_setting(
+				'superpwa_pull_to_refresh_settings_group',		 // Group name
+				'superpwa_pull_to_refresh_settings', 			// Setting name = html form <input> name on settings form
+				'superpwa_pull_to_refresh_validater_sanitizer'	// Input validator and sanitizer
+			);
 
-		// Pull To Refresh
-		add_settings_section(
-			'superpwa_pull_to_refresh_section',				// ID
-			__return_false(),								// Title
-			'',				// Callback Function
-			'superpwa_pull_to_refresh_section'					// Page slug
-		);
+			// Pull To Refresh
+			add_settings_section(
+				'superpwa_pull_to_refresh_section',				// ID
+				__return_false(),								// Title
+				'',				// Callback Function
+				'superpwa_pull_to_refresh_section'					// Page slug
+			);
 
 
-		// Pull To Refresh	
-		add_settings_field(
-			'superpwa_pull_to_refresh_source',							// ID
-			__('Pull To Refresh	', 'super-progressive-web-apps'),	// Title
-			'superpwa_pull_to_refresh_enable_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Pull To Refresh	
+			add_settings_field(
+				'superpwa_pull_to_refresh_source',							// ID
+				__('Pull To Refresh	', 'super-progressive-web-apps'),	// Title
+				'superpwa_pull_to_refresh_enable_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
 
-		// Pull message
-		add_settings_field(
-			'superpwa_pull_to_refresh_pull_message',							// ID
-			__('Pull message', 'super-progressive-web-apps'),	// Title
-			'superpwa_pull_to_refresh_pull_message_text_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Pull message
+			add_settings_field(
+				'superpwa_pull_to_refresh_pull_message',							// ID
+				__('Pull message', 'super-progressive-web-apps'),	// Title
+				'superpwa_pull_to_refresh_pull_message_text_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
 
-		// Release message
-		add_settings_field(
-			'superpwa_pull_to_refresh_release_message',							// ID
-			__('Release message', 'super-progressive-web-apps'),		// Title
-			'superpwa_pull_to_refresh_pull_release_text_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Release message
+			add_settings_field(
+				'superpwa_pull_to_refresh_release_message',							// ID
+				__('Release message', 'super-progressive-web-apps'),		// Title
+				'superpwa_pull_to_refresh_pull_release_text_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
 
-		// Refreshing message
-		add_settings_field(
-			'superpwa_pull_to_refresh_refreshing',							// ID
-			__('Refreshing message', 'super-progressive-web-apps'),		// Title
-			'superpwa_pull_to_refresh_refreshing_text_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Refreshing message
+			add_settings_field(
+				'superpwa_pull_to_refresh_refreshing',							// ID
+				__('Refreshing message', 'super-progressive-web-apps'),		// Title
+				'superpwa_pull_to_refresh_refreshing_text_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
 
-		// Font size
-		add_settings_field(
-			'superpwa_pull_to_refresh_font_size',						// ID
-			__('Font size', 'super-progressive-web-apps'),	// Title
-			'superpwa_pull_to_refresh_font_size_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Font size
+			add_settings_field(
+				'superpwa_pull_to_refresh_font_size',						// ID
+				__('Font size', 'super-progressive-web-apps'),	// Title
+				'superpwa_pull_to_refresh_font_size_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
 
-		// Font Color
-		add_settings_field(
-			'superpwa_pull_to_refresh_font_color',						// ID
-			__('Font Color', 'super-progressive-web-apps'),	// Title
-			'superpwa_pull_to_refresh_font_color_cb',						// CB
-			'superpwa_pull_to_refresh_section',						// Page slug
-			'superpwa_pull_to_refresh_section'							// Settings Section ID
-		);
+			// Font Color
+			add_settings_field(
+				'superpwa_pull_to_refresh_font_color',						// ID
+				__('Font Color', 'super-progressive-web-apps'),	// Title
+				'superpwa_pull_to_refresh_font_color_cb',						// CB
+				'superpwa_pull_to_refresh_section',						// Page slug
+				'superpwa_pull_to_refresh_section'							// Settings Section ID
+			);
+
+		}
+		
 	}
+
 	add_action('admin_init', 'superpwa_pull_to_refresh_register_settings');
 
 /**
@@ -273,7 +281,10 @@ function superpwa_pull_to_refresh_font_color_cb()
  */
 function superpwa_pull_to_refresh_interface_render()
 {
-	// Authentication
+
+	if ( superpwa_addons_status( 'pull_to_refresh' ) 	== 'active' ) {
+
+		// Authentication
 	if (!current_user_can('manage_options')) {
 		return;
 	}
@@ -293,10 +304,7 @@ function superpwa_pull_to_refresh_interface_render()
 ?>
 
 	<div class="wrap">
-		<h1><?php esc_html_e('Pull To Refresh', 'super-progressive-web-apps'); ?>
-			<!-- <small>(<a href="<?php //echo esc_url($addon_pull_to_refresh['link']) . '?utm_source=superpwa-plugin&utm_medium=utm-tracking-settings'
-									?>"><?php //echo esc_html__( 'Docs', 'super-progressive-web-apps' ); 
-										?></a>)</small> -->
+		<h1><?php esc_html_e('Pull To Refresh', 'super-progressive-web-apps'); ?>			
 		</h1>
 
 		<?php superpwa_setting_tabs_html(); ?>
@@ -314,17 +322,29 @@ function superpwa_pull_to_refresh_interface_render()
 			?>
 		</form>
 	</div>
-	<?php //superpwa_newsletter_form(); 
-	?>
-<?php
+	<?php	
+
+	}	
 }
 
-if(!function_exists('superpwa_pull_to_refresh_ptrfp_scripts_load')){
-	function superpwa_pull_to_refresh_ptrfp_scripts_load(){
+
+
+function superpwa_pull_to_refresh_ptrfp_scripts_load() {
+
+	if ( superpwa_addons_status( 'pull_to_refresh' ) 	== 'active' ) {
+
 		if(function_exists('superpwa_pull_to_refresh_get_settings')){
-				$settings = superpwa_pull_to_refresh_get_settings();
-			}else{ $settings = array(); }
+
+			$settings = superpwa_pull_to_refresh_get_settings();
+
+		}else{ 
+
+			$settings = array(); 
+
+		}
+
 		if( isset($settings['superpwa_pull_to_refresh_switch'])  && $settings['superpwa_pull_to_refresh_switch'] ==1 ){
+
 			wp_register_script( "superpwa_ptrfp_lib_script", SUPERPWA_PATH_SRC."admin/js/superpwa-ptr-lib.min.js", array('jquery'), SUPERPWA_VERSION, true );
 			$ptrArray = array(
 						'instrPullToRefresh'=> ( isset( $settings['superpwa_ptr_text'] )? $settings['superpwa_ptr_text'] : esc_html__("Pull down to refresh", 'pull-to-refresh-for-pwa') ),
@@ -337,6 +357,9 @@ if(!function_exists('superpwa_pull_to_refresh_ptrfp_scripts_load')){
 			wp_enqueue_script( "superpwa_ptrfp_lib_script");
 
 		}
+
 	}
-	add_action("wp_enqueue_scripts", 'superpwa_pull_to_refresh_ptrfp_scripts_load');
+	
 }
+
+add_action("wp_enqueue_scripts", 'superpwa_pull_to_refresh_ptrfp_scripts_load');

--- a/addons/utm-tracking.php
+++ b/addons/utm-tracking.php
@@ -54,24 +54,34 @@ function superpwa_utm_tracking_get_settings() {
  * @since 1.7
  */
 function superpwa_utm_tracking_for_start_url( $start_url ) {
-	
-	// Get UTM Tracking settings
-	$utm_params = superpwa_utm_tracking_get_settings();
-	
-	// Add the initial '/?'
-	$start_url = trailingslashit( $start_url ) . '?';
-	
-	// Build the URL
-	foreach ( $utm_params as $param => $value ) {
+
+	if ( superpwa_addons_status( 'utm_tracking' ) == 'active' ) {
+
+		// Get UTM Tracking settings
+		$utm_params = superpwa_utm_tracking_get_settings();
 		
-		if ( ! empty( $value ) ) {
-			$start_url = $start_url . $param . '=' . rawurlencode( $value ) . '&';
+		// Add the initial '/?'
+		$start_url = trailingslashit( $start_url ) . '?';
+		
+		// Build the URL
+		foreach ( $utm_params as $param => $value ) {
+			
+			if ( ! empty( $value ) ) {
+				$start_url = $start_url . $param . '=' . rawurlencode( $value ) . '&';
+			}
 		}
+		
+		// Remove trailing '&'
+		return rtrim( $start_url, '&' );
+
+	}else{
+
+		return $start_url;
+
 	}
-	
-	// Remove trailing '&'
-	return rtrim( $start_url, '&' );
+		
 }
+
 add_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url' );
 
 /**
@@ -83,10 +93,14 @@ add_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url'
  * @since	1.7
  */
 function superpwa_utm_tracking_save_settings_todo() {
+
+	if ( superpwa_addons_status( 'utm_tracking' ) == 'active' ) {
+		// Regenerate manifest
+		superpwa_generate_manifest();
+	}
 	
-	// Regenerate manifest
-	superpwa_generate_manifest();
 }
+
 add_action( 'add_option_superpwa_utm_tracking_settings', 'superpwa_utm_tracking_save_settings_todo' );
 add_action( 'update_option_superpwa_utm_tracking_settings', 'superpwa_utm_tracking_save_settings_todo' );
 add_action( 'superpwa_addon_activated_utm_tracking', 'superpwa_utm_tracking_save_settings_todo' );
@@ -100,11 +114,14 @@ add_action( 'superpwa_addon_activated_utm_tracking', 'superpwa_utm_tracking_save
  */
 function superpwa_utm_tracking_deactivate_todo() {
 	
-	// Unhook the UTM tracking params filter
-	remove_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url' );
+	if ( superpwa_addons_status( 'utm_tracking' ) == 'active' ) {
+		// Unhook the UTM tracking params filter
+		remove_filter( 'superpwa_manifest_start_url', 'superpwa_utm_tracking_for_start_url' );
 	
-	// Regenerate manifest
-	superpwa_generate_manifest();
+		// Regenerate manifest
+		superpwa_generate_manifest();
+	}
+	
 }
 add_action( 'superpwa_addon_deactivated_utm_tracking', 'superpwa_utm_tracking_deactivate_todo' );
 
@@ -115,7 +132,9 @@ add_action( 'superpwa_addon_deactivated_utm_tracking', 'superpwa_utm_tracking_de
  */
 function superpwa_utm_tracking_register_settings() {
 
-	// Register Setting
+	if ( superpwa_addons_status( 'utm_tracking' ) == 'active' ){
+
+		// Register Setting
 	register_setting( 
 		'superpwa_utm_tracking_settings_group',		 // Group name
 		'superpwa_utm_tracking_settings', 			// Setting name = html form <input> name on settings form
@@ -183,6 +202,9 @@ function superpwa_utm_tracking_register_settings() {
 			'superpwa_utm_tracking_section',						// Page slug
 			'superpwa_utm_tracking_section'							// Settings Section ID
 		);	
+
+	}
+	
 }
 add_action( 'admin_init', 'superpwa_utm_tracking_register_settings' );
 
@@ -348,8 +370,10 @@ function superpwa_utm_tracking_content_cb() {
  * @since 1.7
  */ 
 function superpwa_utm_tracking_interface_render() {
-	
-	// Authentication
+
+	if ( superpwa_addons_status( 'utm_tracking' ) == 'active' ) {
+
+		// Authentication
 
 	if ( ! current_user_can( superpwa_current_user_can() ) ) {
         return;
@@ -391,4 +415,7 @@ function superpwa_utm_tracking_interface_render() {
 	</div>
 	<?php superpwa_newsletter_form(); ?>
 	<?php
+
+	}
+		
 }

--- a/admin/admin-ui-render-addons.php
+++ b/admin/admin-ui-render-addons.php
@@ -561,9 +561,7 @@ function superpwa_addons_status( $slug ) {
 
 			// If we are here, add-on is not installed and not active
 			return 'upgrade';
-			
-			
-			
+									
 			break;
 			
 		default:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+= 2.2.33 =
+* Date: [20.December.2024](https://superpwa.com/superpwa-2-2-33-release-note/?utm_source=wordpress.org&utm_medium=changelog)
+* BugFixed: WP 6.7.0: Translations loaded too early #572
+* BugFixed: Start_url not getting updated in manifest and when multilingual option enabled and directly deactivated addon #570
+* BugFixed: Function _load_textdomain_just_in_time was called incorrectly. #571
+* BugFixed: If the option to display the CTA banner on IOS is unchecked, the CTA install button added using shortcode also stops working on IOS devices. #569
+* BugFixed: Conflict issue with Visibility extension #566
+* Improvement: Change screenshots on plugin details page #546
+* Feature: Need to added the feature in Nav Bar extension. #567
+
 = 2.2.32 =
 * Date: [26.November.2024](https://superpwa.com/superpwa-2-2-32-release-note/?utm_source=wordpress.org&utm_medium=changelog)
 * Feature: Added feature of Offline form. #297

--- a/loader.php
+++ b/loader.php
@@ -33,10 +33,10 @@ require_once( SUPERPWA_PATH_ABS . 'public/sw.php' );
 require_once( SUPERPWA_PATH_ABS . 'public/amphtml.php' );
 
 // Load bundled add-ons
-if ( superpwa_addons_status( 'utm_tracking' ) 		== 'active' ) require_once( SUPERPWA_PATH_ABS . 'addons/utm-tracking.php' );
-if ( superpwa_addons_status( 'apple_touch_icons' ) 	== 'active' ) require_once( SUPERPWA_PATH_ABS . 'addons/apple-touch-icons.php' );
-if ( superpwa_addons_status( 'caching_strategies' ) 	== 'active' ) require_once( SUPERPWA_PATH_ABS . 'addons/caching-strategies.php' );
-if ( superpwa_addons_status( 'pull_to_refresh' ) 	== 'active' ) require_once( SUPERPWA_PATH_ABS . 'addons/pull-to-refresh.php' );
+require_once( SUPERPWA_PATH_ABS . 'addons/utm-tracking.php' );
+require_once( SUPERPWA_PATH_ABS . 'addons/apple-touch-icons.php' );
+require_once( SUPERPWA_PATH_ABS . 'addons/caching-strategies.php' );
+require_once( SUPERPWA_PATH_ABS . 'addons/pull-to-refresh.php' );
 
 // superpwa-push-notification
 require_once( SUPERPWA_PATH_ABS . 'addons/superpwa-push-notification.php' );

--- a/public/js/register-sw.js
+++ b/public/js/register-sw.js
@@ -288,11 +288,14 @@ window.mobileCheck = function() {
 	});
 
 	document.addEventListener('DOMContentLoaded', function () {
-		const reffer = document.referrer; 
-		if (reffer && reffer.includes('android-app://')) {
-			sessionStorage.setItem('superpwa_mode','apk');
-		} 
+		if (typeof pnScriptSetting !== 'undefined' && pnScriptSetting.superpwa_apk_only !== undefined && pnScriptSetting.superpwa_apk_only == 1) {
+			const reffer = document.referrer; 
+			if (reffer && reffer.includes('android-app://')) {
+				sessionStorage.setItem('superpwa_mode', 'apk');
+			}
+		}
 	});
+	
 
 	if (superpwa_sw.offline_form_addon_active) {
 		navigator.serviceWorker.ready.then(function (registration) {

--- a/public/js/register-sw.js
+++ b/public/js/register-sw.js
@@ -287,6 +287,13 @@ window.mobileCheck = function() {
 
 	});
 
+	document.addEventListener('DOMContentLoaded', function () {
+		const reffer = document.referrer; 
+		if (reffer && reffer.includes('android-app://')) {
+			sessionStorage.setItem('superpwa_mode','apk');
+		} 
+	});
+
 	if (superpwa_sw.offline_form_addon_active) {
 		navigator.serviceWorker.ready.then(function (registration) {
 			return registration.sync.register('superpwa_form_sendFormData')

--- a/public/manifest.php
+++ b/public/manifest.php
@@ -209,42 +209,48 @@ function superpwa_manifest_template( $pageid = null ) {
 		}
 
 		$is_any_multilang_enable = false;
-		$wpml_settings = get_option( 'superpwa_wpml_settings');
-
-		if (isset($wpml_settings['enable_wpml']) && $wpml_settings['enable_wpml'] == 1) {
-			$current_language = superpwa_get_language_shortcode();
-			$start_url = superpwa_home_url().$current_language;
-			$manifest['start_url'] = $start_url;
-			$manifest['scope'] = "/";
-			$is_any_multilang_enable = true;
+		$active_addons = get_option( 'superpwa_active_addons', array() );
+		if (in_array('wpml_for_superpwa',$active_addons)) {
+			$wpml_settings = get_option( 'superpwa_wpml_settings');
+			if (isset($wpml_settings['enable_wpml']) && $wpml_settings['enable_wpml'] == 1) {
+				$current_language = superpwa_get_language_shortcode();
+				$start_url = superpwa_home_url().$current_language;
+				$manifest['start_url'] = $start_url;
+				$manifest['scope'] = "/";
+				$is_any_multilang_enable = true;
+			}
 		}
-
-		$wpmultilang_settings = get_option( 'superpwa_wp_multilang_settings');
-		if (isset($wpmultilang_settings['enable_wp_multilang']) && $wpmultilang_settings['enable_wp_multilang'] == 1 && function_exists("wpm_get_languages")) {
-			$current_language = wpm_get_language();
-			$start_url = superpwa_home_url().$current_language;
-			$manifest['start_url'] = $start_url;
-			$manifest['scope'] = "/";
-			$is_any_multilang_enable = true;
+		if (in_array('wp_multilang_for_superpwa',$active_addons)) {
+			$wpmultilang_settings = get_option( 'superpwa_wp_multilang_settings');
+			if (isset($wpmultilang_settings['enable_wp_multilang']) && $wpmultilang_settings['enable_wp_multilang'] == 1 && function_exists("wpm_get_languages")) {
+				$current_language = wpm_get_language();
+				$start_url = superpwa_home_url().$current_language;
+				$manifest['start_url'] = $start_url;
+				$manifest['scope'] = "/";
+				$is_any_multilang_enable = true;
+			}
 		}
-
-		$polylang_settings = get_option( 'superpwa_polylang_settings');
-		if (isset($polylang_settings['enable_polylang']) && $polylang_settings['enable_polylang'] == 1 && function_exists("pll_default_language")) {
-			$current_language = pll_current_language();
-			$start_url = superpwa_home_url().$current_language;
-			$manifest['start_url'] = $start_url;
-			$manifest['scope'] = "/";
-			$is_any_multilang_enable = true;
+		if (in_array('polylang_for_superpwa',$active_addons)) {
+			$polylang_settings = get_option( 'superpwa_polylang_settings');
+			if (isset($polylang_settings['enable_polylang']) && $polylang_settings['enable_polylang'] == 1 && function_exists("pll_default_language")) {
+				$current_language = pll_current_language();
+				$start_url = superpwa_home_url().$current_language;
+				$manifest['start_url'] = $start_url;
+				$manifest['scope'] = "/";
+				$is_any_multilang_enable = true;
+			}
 		}
-		$translatepress_settings = get_option( 'superpwa_translatepress_settings');
-		if (isset($translatepress_settings['enable_translatepress']) && $translatepress_settings['enable_translatepress'] == 1 && class_exists('TRP_Translate_Press')) {
-			$homeUrl = superpwa_home_url();
-			global $TRP_LANGUAGE;
-			$trp = TRP_Translate_Press::get_trp_instance();
-			$start_url = $trp->get_component('url_converter')->get_url_for_language($TRP_LANGUAGE, $homeUrl);
-			$manifest['start_url'] = $homeUrl;
-			$manifest['scope'] = "/";
-			$is_any_multilang_enable = true;
+		if (in_array('translatepress_for_superpwa',$active_addons)) {
+			$translatepress_settings = get_option( 'superpwa_translatepress_settings');
+			if (isset($translatepress_settings['enable_translatepress']) && $translatepress_settings['enable_translatepress'] == 1 && class_exists('TRP_Translate_Press')) {
+				$homeUrl = superpwa_home_url();
+				global $TRP_LANGUAGE;
+				$trp = TRP_Translate_Press::get_trp_instance();
+				$start_url = $trp->get_component('url_converter')->get_url_for_language($TRP_LANGUAGE, $homeUrl);
+				$manifest['start_url'] = $homeUrl;
+				$manifest['scope'] = "/";
+				$is_any_multilang_enable = true;
+			}
 		}
 		if ($is_any_multilang_enable) {
 			superpwa_delete_manifest();

--- a/public/sw.php
+++ b/public/sw.php
@@ -125,16 +125,6 @@ function superpwa_generate_sw() {
 	
 	// Get Settings
 	$settings = superpwa_get_settings();
-
-	$wpml_settings = get_option( 'superpwa_wpml_settings');
-
-	if (isset($wpml_settings['enable_wpml']) && $wpml_settings['enable_wpml'] == 1) {
-		$current_language = superpwa_get_language_shortcode();
-		$start_url = superpwa_home_url().$current_language;
-		$manifest['start_url'] = $start_url;
-		$manifest['scope'] = "/";
-	}
-	
 	// Return true if dynamic file returns a 200 response.
 	if ( superpwa_file_exists( home_url( '/' ) . superpwa_get_sw_filename() ) && defined( 'WP_CACHE' ) && ! WP_CACHE ) {
 		

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,8 @@ Feel free to get in touch if you have any questions.
 == Screenshots ==
 
 1. Settings page in WordPress Admin > SuperPWA > Settings
+2. Addons in WordPress Admin > SuperPWA > Features(Addons)
+3. Advanced settings in WordPress Admin > SuperPWA > Advanced
 
 == Changelog ==
 = 2.2.32 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pwa, progressive web apps, android app, chrome app, add to homescreen
 Requires at least: 3.6.0
 Tested up to: 6.7
 Requires PHP: 5.3
-Stable tag: 2.2.32
+Stable tag: 2.2.33
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -191,6 +191,16 @@ Feel free to get in touch if you have any questions.
 3. Advanced settings in WordPress Admin > SuperPWA > Advanced
 
 == Changelog ==
+= 2.2.33 =
+* Date: [20.December.2024](https://superpwa.com/superpwa-2-2-33-release-note/?utm_source=wordpress.org&utm_medium=changelog)
+* BugFixed: WP 6.7.0: Translations loaded too early #572
+* BugFixed: Start_url not getting updated in manifest and when multilingual option enabled and directly deactivated addon #570
+* BugFixed: Function _load_textdomain_just_in_time was called incorrectly. #571
+* BugFixed: If the option to display the CTA banner on IOS is unchecked, the CTA install button added using shortcode also stops working on IOS devices. #569
+* BugFixed: Conflict issue with Visibility extension #566
+* Improvement: Change screenshots on plugin details page #546
+* Feature: Need to added the feature in Nav Bar extension. #567
+
 = 2.2.32 =
 * Date: [26.November.2024](https://superpwa.com/superpwa-2-2-32-release-note/?utm_source=wordpress.org&utm_medium=changelog)
 * Feature: Added feature of Offline form. #297
@@ -287,14 +297,6 @@ Feel free to get in touch if you have any questions.
 * Date: [28.November.2023](https://superpwa.com/superpwa-2-2-22-release-note/?utm_source=wordpress.org&utm_medium=changelog)
 * BugFixed: Role Based Access is not working #472
 * BugFixed: Fixed Broken Access Control vulnerability [Learn More](https://patchstack.com/database/vulnerability/super-progressive-web-apps/wordpress-super-progressive-web-apps-plugin-2-2-21-broken-access-control-vulnerability)
-
-= 2.2.21 =
-* Date: [18.October.2023](https://superpwa.com/superpwa-2-2-21-release-note/?utm_source=wordpress.org&utm_medium=changelog)
-* BugFixed: Push notification is not working on IOS. #468
-* Feature: Added Notification badge on the PWA icon #212
-* BugFixed: Role Based Access is not working #472
-* BugFixed: If add-on is not activated than do not show the settings button #470
-* BugFixed: The button network deactivate is not working #475
 
 
 Full changelog available [ at changelog.txt](https://plugins.svn.wordpress.org/super-progressive-web-apps/trunk/changelog.txt)

--- a/superpwa.php
+++ b/superpwa.php
@@ -6,7 +6,7 @@
  * Author: SuperPWA
  * Author URI: https://profiles.wordpress.org/superpwa/
  * Contributors: SuperPWA
- * Version: 2.2.32
+ * Version: 2.2.33
  * Text Domain: super-progressive-web-apps
  * Domain Path: /languages
  * License: GPL2
@@ -43,7 +43,7 @@ if ( ! defined('ABSPATH') ) exit;
  * @since 1.0
  */
 if ( ! defined( 'SUPERPWA_VERSION' ) ) {
-	define( 'SUPERPWA_VERSION'	, '2.2.32' ); 
+	define( 'SUPERPWA_VERSION'	, '2.2.33' ); 
 }
 
 /**


### PR DESCRIPTION
= 2.2.33 =
* Date: [20.December.2024](https://superpwa.com/superpwa-2-2-33-release-note/?utm_source=wordpress.org&utm_medium=changelog)
* BugFixed: WP 6.7.0: Translations loaded too early #572
* BugFixed: Start_url not getting updated in manifest and when multilingual option enabled and directly deactivated addon #570
* BugFixed: Function _load_textdomain_just_in_time was called incorrectly. #571
* BugFixed: If the option to display the CTA banner on IOS is unchecked, the CTA install button added using shortcode also stops working on IOS devices. #569
* BugFixed: Conflict issue with Visibility extension #566
* Improvement: Change screenshots on plugin details page #546
* Feature: Need to added the feature in Nav Bar extension. #567